### PR TITLE
Feature/seo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The aim of Peak is to make it easy to start new projects as they often share muc
 * [Navigation](#navigation)
 * [Page builder](#page-builder)
 * [Pagination](#pagination)
+* [SEO](#seo)
 * [Statamic login screen](#statamic-login-screen)
 * [Typography](#typography)
 
@@ -202,6 +203,29 @@ For example if you add a fieldset to the `page_builder.yaml` with the handle `ca
 When you're working with the collection tag and want to use [pagination](https://statamic.dev/tags/collection#pagination), just add the pagination partial using `partial:components/pagination` to automagically add pagination buttons. They're easily editable in  `resources/views/components/_pagination.antlers.html`. 
 
 > Note: the strings used in the partial are translatable and can be edited in `resources/lang/en/site.php`.
+
+## SEO
+<span id="seo"></span>
+
+Peak includes basic bare bones SEO support that's easy to expand on or replace with a professional addon like [Aardvark SEO]() or [SEO Pro](). Currently you can edit site settings in globals:
+* Site title
+* Page titel separator
+
+On an entry basis you can edit the following:
+* Entry title
+* Entry description
+* noindex
+
+If you plan on using an addon. Do the following:
+* Remove `{{ partial:snippets/seo }}` from `resources/views/layout.antlers.html`.
+* Remove the SEO section and import from `resources/blueprints/collections/pages/page.yaml`.
+* Delete the SEO global `content/globals/seo.yaml`.
+
+And optionally to erase all traces:
+* Delete the SEO global blueprint `resources/blueprints/globals/seo.yaml`.
+* Delete the SEO fieldset `resources/fieldsets/seo.yaml`.
+* Delete the SEO partial `resources/views/snippets/_seo.antlers.html`.
+
 
 ## Statamic login screen
 <span id="statamic-login-screen"></span>

--- a/content/globals/seo.yaml
+++ b/content/globals/seo.yaml
@@ -1,0 +1,1 @@
+title: SEO

--- a/resources/blueprints/collections/pages/page.yaml
+++ b/resources/blueprints/collections/pages/page.yaml
@@ -6,8 +6,15 @@ sections:
       -
         handle: title
         field: common.title
+        config:
+          required: true
       -
         import: page_builder
+  seo:
+    display: SEO
+    fields:
+      -
+        import: seo
   sidebar:
     display: Sidebar
     fields:
@@ -22,3 +29,13 @@ sections:
       -
         handle: slug
         field: common.slug
+        config:
+          required: true
+      -
+        handle: parent
+        field:
+          type: entries
+          collections:
+            - pages
+          max_items: 1
+          listable: false

--- a/resources/blueprints/globals/seo.yaml
+++ b/resources/blueprints/globals/seo.yaml
@@ -1,0 +1,40 @@
+sections:
+  basic:
+    display: Basic
+    fields:
+      -
+        handle: section_title
+        field:
+          type: section
+          instructions: 'The website title'
+          localizable: false
+          listable: false
+          display: Title
+      -
+        handle: title_separator
+        field:
+          options:
+            ' | ': '|'
+            ' - ': '-'
+            ' / ': '/'
+            ' :: ': '::'
+            ' > ': '>'
+          clearable: false
+          multiple: false
+          searchable: true
+          taggable: false
+          push_tags: false
+          cast_booleans: false
+          type: select
+          instructions: 'Select the character to separate the page title and site title.'
+          localizable: false
+          width: 33
+          listable: hidden
+          display: Separator
+      -
+        handle: site_name
+        field: common.title
+        config:
+          display: 'Website title'
+          instructions: 'The title for the website. Defaults to Laravel''s App Name.'
+          width: 66

--- a/resources/fieldsets/seo.yaml
+++ b/resources/fieldsets/seo.yaml
@@ -1,0 +1,22 @@
+title: SEO
+fields:
+  -
+    handle: seo_title
+    field: common.title
+    config:
+      character_limit: 70
+      instructions: 'This entries SEO title, defaults to title. Max 70 characters including the site name.'
+  -
+    handle: seo_description
+    field: common.text_plain
+    config:
+      character_limit: '160'
+      instructions: 'This entries SEO description. Max 160 characters.'
+  -
+    handle: seo_noindex
+    field:
+      type: toggle
+      instructions: 'Don''t index this entry.'
+      localizable: false
+      listable: hidden
+      display: No-index

--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -4,8 +4,8 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-        {{# Replace the following line with the SEO Pro or Aardvark SEO tag. #}}
-        <title>{{ if title }}{{ title }} | {{ /if }}{{ site:name }}</title>
+        {{# Replace the following line with the SEO Pro or Aardvark SEO tag if you want to use an addon for SEO. Also remove the seo section in you page blueprint.#}}
+        {{ partial:snippets/seo }}
         <link rel="stylesheet" href="{{ mix src='css/site.css' }}">
         {{# Generate your favicons here https://realfavicongenerator.net #}}
     </head>

--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -1,0 +1,12 @@
+{{# The SEO partial rendered in the <head> of your page. You don't need to use this file if you plan on using an addon for SEO. #}}
+<title>
+    {{ seo_title ? seo_title : title }}
+    {{ seo:title_separator ? seo:title_separator : " &#124; " }}
+    {{ seo:site_name ? seo:site_name : site:name }}
+</title>
+{{ if seo_description }}
+    <meta name="description" content="{{ seo_description }}">
+{{ /if }}
+{{ if seo_noindex }}
+    <meta name="robots" content="noindex">
+{{ /if }}


### PR DESCRIPTION
Peak includes basic bare bones SEO support that's easy to expand on or replace with a professional addon like [Aardvark SEO](https://statamic.com/addons/candour/aardvark-seo) (at time of writing not yet released for v3) or [SEO Pro](https://statamic.com/addons/statamic/seo-pro). Currently you can edit site settings in globals:
* Site title
* Page titel separator

On an entry basis you can edit the following:
* Entry title
* Entry description
* noindex

If you plan on using an addon. Do the following:
* Remove `{{ partial:snippets/seo }}` from `resources/views/layout.antlers.html`.
* Remove the SEO section and import from `resources/blueprints/collections/pages/page.yaml`.
* Delete the SEO global blueprint `resources/blueprints/globals/seo.yaml`.

And optionally to erase all traces:
* Delete the SEO global data `content/globals/seo.yaml`.
* Delete the SEO fieldset `resources/fieldsets/seo.yaml`.
* Delete the SEO partial `resources/views/snippets/_seo.antlers.html`.

Closes #15 