### PR TITLE
Add custom picture partial in favor of 3d party package

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,20 @@ The config file also includes the [Tailwind Custom Forms](https://tailwindcss-cu
 
 When your app environment is `local`, Peak will add a breakpoint notice to your site so you can tell on which breakpoint you're currently displaying the website. You can turn this off by removing `{{ environment == 'local' ? 'debug' : '' }}` from `resources/views/layout.antlers.html`.
 
-
 # Features
 
 ## Assets
 <span id="assets"></span>
 
 ### Images
-Peak comes with Spaties Responsive Images package for Statamic. This package will generate multiple sizes for your assets and will provide the browser with instructions on which versions to use depending on the screen size and the way the image is rendered. Adding responsive images to your site *couldn't* be easier. Check out their [documentation](https://github.com/spatie/statamic-responsive-images).
+Peak comes a picture partial that will add responsive sourcesets to your images. The variants generated are defined in `config/statamic/assets.php` and cover most use cases. In `resources/views/components/_figure.antlers.html` you can see an example of how to include the picture partial. It accepts the following arguments:
+
+* `image`: *asset*, the actual image variable.
+* `class`: *string*, optional css classes that should be applied to the image.
+* `cover`: *boolean*, true means the image should cover the containing element.
+* `sizes`: *string*, the sizes attribute that informs the browser how the image should be rendered.
+
+See [this article](https://studio1902.nl/blog/responsive-images-with-statamic-tailwind-and-glide/) for more information.
 
 ### Background images
 Peak comes with a background image snippet you can use to apply responsive images (WebP included) to an elements background. Just use `{{ partial:snippets/background_image image="YOUR_IMAGE" class="CLASS_OF_ELEMENT_THAT_NEEDS_BG_IMAGE" }}`. The predefined sizes used in `resources/views/snippets/_background_image.antlers.html` are defined in `config/statamic/assets.php`.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",
-        "spatie/statamic-responsive-images": "^1.2",
         "statamic/cms": "3.0.*@beta"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0690a671f6684ab4925ae6daa9676203",
+    "content-hash": "7e6e1b61361eb4eebfaa6bdb9280b6b9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3569,44 +3569,6 @@
                 "spatie"
             ],
             "time": "2020-02-16T19:18:04+00:00"
-        },
-        {
-            "name": "spatie/statamic-responsive-images",
-            "version": "v1.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/statamic-responsive-images.git",
-                "reference": "c2436ffde2155394e301150a9ac8f978ba4168df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/statamic-responsive-images/zipball/c2436ffde2155394e301150a9ac8f978ba4168df",
-                "reference": "c2436ffde2155394e301150a9ac8f978ba4168df",
-                "shasum": ""
-            },
-            "type": "statamic-addon",
-            "extra": {
-                "statamic": {
-                    "name": "Responsive Images",
-                    "description": "Responsive Images for Statamic 3"
-                },
-                "laravel": {
-                    "providers": [
-                        "Spatie\\ResponsiveImages\\ServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\ResponsiveImages\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Responsive Images for Statamic 3",
-            "time": "2020-08-07T07:21:02+00:00"
         },
         {
             "name": "statamic/cms",

--- a/config/statamic/assets.php
+++ b/config/statamic/assets.php
@@ -67,10 +67,12 @@ return [
         */
 
         'presets' => [
+            'xs-webp' => ['w' => 320, 'h' => 10000, 'q' => 85, 'fit' => 'contain', 'fm' => 'webp'],
             'sm-webp' => ['w' => 480, 'h' => 10000, 'q' => 85, 'fit' => 'contain', 'fm' => 'webp'],
             'md-webp' => ['w' => 768, 'h' => 10000, 'q' => 85, 'fit' => 'contain', 'fm' => 'webp'],
             'lg-webp' => ['w' => 1280, 'h' => 10000, 'q' => 85, 'fit' => 'contain', 'fm' => 'webp'],
             'xl-webp' => ['w' => 1440, 'h' => 10000, 'q' => 85, 'fit' => 'contain', 'fm' => 'webp'],
+            'xs' => ['w' => 320, 'h' => 10000, 'q' => 85, 'fit' => 'contain'],
             'sm' => ['w' => 480, 'h' => 10000, 'q' => 85, 'fit' => 'contain'],
             'md' => ['w' => 768, 'h' => 10000, 'q' => 85, 'fit' => 'contain'],
             'lg' => ['w' => 1280, 'h' => 10000, 'q' => 85, 'fit' => 'contain'],

--- a/resources/views/components/_figure.antlers.html
+++ b/resources/views/components/_figure.antlers.html
@@ -1,6 +1,20 @@
 {{# A sizeable image rendered in a figure tag with optional caption. #}}
 <figure class="size-{{ size }}">
-    {{ responsive:image }}
+    {{ 
+        partial:components/picture 
+        :image="image" 
+        class="w-full" 
+        cover="false" 
+        {{ if size == 'sm'}}
+            sizes="(min-width: 768px) 35vw, 90vw" 
+        {{ elseif size == 'md' }}
+            sizes="(min-width: 768px) 55vw, 90vw" 
+        {{ elseif size == 'lg' }}
+            sizes="(min-width: 768px) 75vw, 90vw" 
+        {{ elseif size == 'xl' }}
+            sizes="90vw" 
+        {{ /if }}
+    }}
     {{ if caption }}
         <figcaption class="mt-2 text-neutral-500">
             {{ caption }}

--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -1,0 +1,43 @@
+<picture>
+    {{ asset :url="image" }}
+        {{ if extension == 'svg' || extension == 'gif' }}
+            <img class="{{ class }}" src="{{ url }}" alt="{{ alt }}" />
+        {{ else }}
+            <source
+                srcset="
+                    {{ glide:url preset='xs-webp' }} 320w,
+                    {{ glide:url preset='sm-webp' }} 480w,
+                    {{ glide:url preset='md-webp' }} 768w,
+                    {{ glide:url preset='lg-webp' }} 1280w,
+                    {{ glide:url preset='xl-webp' }} 1440w"
+                sizes="{{ sizes }}"
+                type="image/webp"
+            >
+            <source
+                srcset="
+                    {{ glide:url preset='xs' }} 320w,
+                    {{ glide:url preset='sm' }} 480w,
+                    {{ glide:url preset='md' }} 768w,
+                    {{ glide:url preset='lg' }} 1280w,
+                    {{ glide:url preset='xl' }} 1440w"
+                sizes="{{ sizes }}"
+                {{ if extension == 'png' }}
+                    type="image/png"
+                {{ else }}
+                    type="image/jpeg"
+                {{ /if }}
+            >
+            <img
+                {{ if cover }} 
+                    class="object-cover {{ class }}" 
+                    style="object-position: {{ focus | background_position }}"
+                {{ else }}
+                    class="{{ class }}"
+                {{ /if }}
+                src="{{ glide:url preset='lg' }}"
+                alt="{{ alt }}"
+                loading="lazy"
+            >
+        {{ /if }}
+    {{ /asset }}
+</picture>


### PR DESCRIPTION
Adds a picture partial that will add responsive sourcesets to your images. The variants generated are defined in `config/statamic/assets.php` and cover most use cases. In `resources/views/components/_figure.antlers.html` you can see an example of how to include the picture partial. It accepts the following arguments:

* `image`: *asset*, the actual image variable.
* `class`: *string*, optional css classes that should be applied to the image.
* `cover`: *boolean*, true means the image should cover the containing element.
* `sizes`: *string*, the sizes attribute that informs the browser how the image should be rendered.

See [this article](https://studio1902.nl/blog/responsive-images-with-statamic-tailwind-and-glide/) for more information.