### PR TITLE
replace env() with config()

### DIFF
--- a/app/Http/Controllers/DynamicToken.php
+++ b/app/Http/Controllers/DynamicToken.php
@@ -14,10 +14,10 @@ class DynamicToken extends Controller
     public function getRefresh(Request $request)
     {
         // Determine if the request is actually coming from our own website on non local enviroments.
-        if (env('APP_ENV') != 'local')
+        if (config('app.env') != 'local')
         {
             $referer = request()->headers->get('referer');
-            $startWithAppUrl = starts_with($referer, env('APP_URL'));
+            $startWithAppUrl = starts_with($referer, config('app.url'));
             if (empty($referer) || !$startWithAppUrl) {
                 abort(404);
             }

--- a/resources/lang/en/site.php
+++ b/resources/lang/en/site.php
@@ -18,7 +18,7 @@ return [
     'form_mail_body_sender'             => 'Thanks for your message. We will contact you as soon as possible.',
     'form_mail_body_owner'              => 'A contact form has been sent.',
     'form_mail_closing'                 => 'Kind regards',
-    'form_mail_from'                    => env('APP_NAME'),
-    'form_mail_url'                     => env('APP_URL'),
+    'form_mail_from'                    => config('app.name'),
+    'form_mail_url'                     => config('app.url'),
     'form_mail_logo'                    => 'https://studio1902.ams3.cdn.digitaloceanspaces.com/assets/statamic-peak/statamic-peak-logo.svg',
 ];


### PR DESCRIPTION
env() should only be used inside config files as it returns null when the config is cached.

Fixes #21 
