### PR TITLE
Migrate to Tailwind 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,24 +11,24 @@
   "author": "Studio 1902",
   "license": "MIT",
   "dependencies": {
-    "@tailwindcss/aspect-ratio": "^0.1.4",
-    "@tailwindcss/forms": "^0.1.4",
-    "@tailwindcss/typography": "^0.2.0",
-    "alpinejs": "^2.7.0",
+    "@tailwindcss/aspect-ratio": "^0.2.0",
+    "@tailwindcss/forms": "^0.2.1",
+    "@tailwindcss/typography": "^0.3.1",
+    "alpinejs": "^2.7.3",
     "autoprefixer": "^9.8.6",
     "postcss": "^7.0.35",
-    "tailwindcss": "^2.0.1-compat"
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.1"
   },
   "devDependencies": {
-    "browser-sync": "^2.26.12",
+    "browser-sync": "^2.26.13",
     "browser-sync-webpack-plugin": "^2.2.2",
     "cross-env": "^7.0.2",
     "glob-all": "^3.2.1",
-    "laravel-mix": "^5.0.7",
+    "laravel-mix": "^5.0.9",
     "laravel-mix-modernizr": "^1.0.1",
     "postcss-import": "^12.0.1",
     "postcss-nested": "^4.2.3",
-    "resolve-url-loader": "^3.1.1",
+    "resolve-url-loader": "^3.1.2",
     "vue-template-compiler": "^2.6.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "@tailwindcss/forms": "^0.1.4",
     "@tailwindcss/typography": "^0.2.0",
     "alpinejs": "^2.7.0",
-    "tailwindcss": "^1.9.2"
+    "autoprefixer": "^9.8.6",
+    "postcss": "^7.0.35",
+    "tailwindcss": "^2.0.1-compat"
   },
   "devDependencies": {
-    "autoprefixer": "^9.8.6",
     "browser-sync": "^2.26.12",
     "browser-sync-webpack-plugin": "^2.2.2",
     "cross-env": "^7.0.2",

--- a/resources/fieldsets/common.yaml
+++ b/resources/fieldsets/common.yaml
@@ -3,7 +3,7 @@ fields:
   -
     handle: image
     field:
-      mode: grid
+      mode: list
       container: assets
       restrict: false
       allow_uploads: true

--- a/resources/views/components/_button.antlers.html
+++ b/resources/views/components/_button.antlers.html
@@ -1,7 +1,7 @@
 {{# A single button. Faux is used when a button is displayed inside a link (for example in link blocks). #}}
 <{{ tag or 'a' }}
         {{ attribute }}
-        class="inline-flex items-center py-3 px-4 border-2 border-primary-600 font-bold leading-none uppercase tracking-widest text-sm text-primary-600 no-underline select-none whitespace-no-wrap"
+        class="inline-flex items-center py-3 px-4 border-2 border-primary-600 font-bold leading-none uppercase tracking-widest text-sm text-primary-600 no-underline select-none whitespace-nowrap"
         {{ unless faux }}
             {{ partial:components/button_attributes }}
         {{ /unless }}

--- a/resources/views/navigation/_main.antlers.html
+++ b/resources/views/navigation/_main.antlers.html
@@ -40,7 +40,7 @@
                         {{ children }}
                             <li class="">
                                 <a
-                                    class="whitespace-no-wrap text-xs font-bold hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
+                                    class="whitespace-nowrap text-xs font-bold hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
                                     href="{{ url }}"
                                 >
                                     {{ title }}
@@ -105,7 +105,7 @@
                         {{ children }}
                             <li>
                                 <a
-                                    class="whitespace-no-wrap font-bold hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
+                                    class="whitespace-nowrap font-bold hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
                                     href="{{ url }}">
                                     {{ title }}
                                 </a>

--- a/resources/views/vendor/statamic/forms/fields/default.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/default.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full focus:border-primary-600 focus:shadow-outline" :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
+<input class="w-full focus:border-primary-600 focus:ring" :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="{{ input_type ?? 'text' }}" 

--- a/resources/views/vendor/statamic/forms/fields/integer.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/integer.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full focus:border-primary-600 focus:shadow-outline" :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
+<input class="w-full focus:border-primary-600 focus:ring" :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="number" 

--- a/resources/views/vendor/statamic/forms/fields/select.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/select.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<select class="w-full focus:border-primary-600 focus:shadow-outline" name="{{ handle }}{{ multiple ?= "[]" }}" {{ multiple ?= "multiple" }} :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }">
+<select class="w-full focus:border-primary-600 focus:ring" name="{{ handle }}{{ multiple ?= "[]" }}" {{ multiple ?= "multiple" }} :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }">
     {{ unless multiple }}
         <option value>{{ trans key="Please select..." }}</option>
     {{ /unless }}

--- a/resources/views/vendor/statamic/forms/fields/text.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/text.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full focus:border-primary-600 focus:shadow-outline" :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
+<input class="w-full focus:border-primary-600 focus:ring" :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="{{ input_type ?? 'text' }}" 

--- a/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<textarea class="w-full h-32 focus:border-primary-600 focus:shadow-outline " :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
+<textarea class="w-full h-32 focus:border-primary-600 focus:ring " :class="{ 'border-error-600 focus:border-error-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}" 
     rows="5"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
   // The various configurable Tailwind configuration files.
   presets: [
     require('tailwindcss/defaultConfig'),
-    require('./tailwind.config.typography.js'),
+    // require('./tailwind.config.typography.js'),
     require('./tailwind.config.peak.js'),
     require('./tailwind.config.site.js'),
   ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,15 +38,13 @@ module.exports = {
       safelist: ['size-sm', 'size-md', 'size-lg', 'size-xl']
     }
   },
-  // Define all variants available.
+  // Extend variants.
   variants: {
-    boxShadow: ['responsive', 'hover', 'focus', 'group-hover'],
-    backgroundColor: ['responsive', 'hover', 'focus', 'group-hover'],
-    opacity: ['responsive', 'hover', 'focus', 'group-hover'],
-    scale: ['responsive', 'hover', 'focus', 'group-hover'],
-    skew: ['responsive', 'hover', 'focus', 'group-hover'],
-    rotate: ['responsive', 'hover', 'focus', 'group-hover'],
-    textColor: ['responsive', 'hover', 'focus', 'group-hover'],
-    translate: ['responsive', 'hover', 'focus', 'group-hover'],
+    extend: {
+      scale: ['group-hover'],
+      skew: ['group-hover'],
+      rotate: ['group-hover'],
+      translate: ['group-hover'],
+    }
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,13 +20,7 @@ module.exports = {
     require('./tailwind.config.site.js'),
   ],
   // Opt in to future Tailwind features.
-  future: {
-    defaultLineHeights: true,
-    extendedSpacingScale: true,
-    purgeLayersByDefault: true,
-    standardFontWeights: true,
-    removeDeprecatedGapUtilities: true,
-  },
+  future: {  },
   // Dark mode
   dark: 'media', // or 'class'
   experimental: {
@@ -41,7 +35,7 @@ module.exports = {
       './resources/js/**/*.js',
     ],
     options: {
-      whitelist: ['size-sm', 'size-md', 'size-lg', 'size-xl']
+      safelist: ['size-sm', 'size-md', 'size-lg', 'size-xl']
     }
   },
   // Define all variants available.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
   // The various configurable Tailwind configuration files.
   presets: [
     require('tailwindcss/defaultConfig'),
-    // require('./tailwind.config.typography.js'),
+    require('./tailwind.config.typography.js'),
     require('./tailwind.config.peak.js'),
     require('./tailwind.config.site.js'),
   ],

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -20,6 +20,7 @@ module.exports = {
       // Grays (currently default TW blue gray).
       neutral: colors.blueGray,
       // Client primary color (currently default TW blue).
+      // This is the color set you usually change for each project with brand color shades.
       primary: colors.blue,
       // Error styling colors (currently default TW Red).
       error: colors.red,

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -8,6 +8,7 @@
 
 const defaultTheme = require('tailwindcss/defaultTheme')
 const plugin = require('tailwindcss/plugin')
+const colors = require('tailwindcss/colors')
 
 module.exports = {
   theme: {

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -102,7 +102,14 @@ module.exports = {
           ...defaultTheme.fontFamily.serif,
         ],
       }
-    }
+    },
+    // Set default transition durations and easing when using the transition utilities.
+    transitionDuration: {
+      DEFAULT: '200ms',
+    },
+    transitionTimingFunction: {
+      DEFAULT: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    },
   },
   plugins: [
     plugin(function({ addBase, theme }) {

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -117,9 +117,9 @@ module.exports = {
             //--------------------------------------------------------------------------
             // Set sans, serif or mono stack with optional custom font as default.
             //--------------------------------------------------------------------------
-            // fontFamily: theme('fontFamily.mono').join(', '),
-            fontFamily: theme('fontFamily.sans').join(', '),
-            // fontFamily: theme('fontFamily.serif').join(', '),
+            // fontFamily: theme('fontFamily.mono'),
+            fontFamily: theme('fontFamily.sans'),
+            // fontFamily: theme('fontFamily.serif'),
         },
         '::selection': {
             backgroundColor: theme('colors.primary.600'),

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -17,69 +17,16 @@ module.exports = {
       transparent: 'transparent',
       black:   '#000',
       white:  '#fff',
-      // Grays (default TW gray)
-      neutral: {
-        100: '#f7fafc',
-        200: '#edf2f7',
-        300: '#e2e8f0',
-        400: '#cbd5e0',
-        500: '#a0aec0',
-        600: '#718096',
-        700: '#4a5568',
-        800: '#2d3748',
-        900: '#1a202c',
-      },
-      // Client primary color, currently blue.
-      primary: {
-        100: '#ebf8ff',
-        200: '#bee3f8',
-        300: '#90cdf4',
-        400: '#63b3ed',
-        500: '#4299e1',
-        600: '#3182ce',
-        700: '#2b6cb0',
-        800: '#2c5282',
-        900: '#2a4365',
-      },
-      // Error styling colors: red (TW Red)
-      error: {
-        50: '#FDF2F2',
-        100: '#FCE8E8',
-        200: '#FBD5D5',
-        300: '#F8B4B3',
-        400: '#F88080',
-        500: '#F05252',
-        600: '#E02423',
-        700: '#C81F1D',
-        800: '#9B1D1C',
-        900: '#771D1D',
-      },
-      // Notice styling colors: yellow (TW Yellow)
-      notice: {
-        50: '#FDFDEA',
-        100: '#FDF5B2',
-        200: '#FCE96B',
-        300: '#FACA16',
-        400: '#E3A009',
-        500: '#C27805',
-        600: '#9F580B',
-        700: '#8E4B10',
-        800: '#723A14',
-        900: '#643112',
-      },
-      // Success styling colors: green (TW Green)
-      success: {
-        50: '#F3FAF7',
-        100: '#DEF7EC',
-        200: '#BBF0DA',
-        300: '#84E1BC',
-        400: '#30C48D',
-        500: '#0D9F6E',
-        600: '#047A55',
-        700: '#036C4E',
-        800: '#06543F',
-        900: '#024737',
-      },
+      // Grays (currently default TW blue gray).
+      neutral: colors.blueGray,
+      // Client primary color (currently default TW blue).
+      primary: colors.blue,
+      // Error styling colors (currently default TW Red).
+      error: colors.red,
+      // Notice styling colors (currently default TW Amber).
+      notice: colors.amber,
+      // Success styling colors (currently default TW Amber).
+      success: colors.green,
     },
     extend: {
       fontFamily: {


### PR DESCRIPTION
I've been trying to migrate to Tailwind 2 but it doesn't seem to play nice with Laravel Mix for now. Or probably Laravel Mix doesn't support PostCSS 8. Who knows? I don't, it's complicated stuff.

Using Tailwind 2's [compatibility mode](https://tailwindcss.com/docs/installation#post-css-7-compatibility-build) should bypass this, but the typography plugin doesn't seem to support compatibility mode (yet). 

However I did follow all the instructions in the [upgrade guide](https://tailwindcss.com/docs/upgrading-to-v2) so it should be ready to go when we can install and compile Tailwind 2 without errors using Laravel Mix. Peak already opted in to most future features so it shouldn't be much of a change.

All the above is coming from my interpretation of npm errors so I'm probably way off. 

If anyone knows how to upgrade I'd love some help.

[What's new in Tailwind 2](https://blog.tailwindcss.com/tailwindcss-v2#default-transition-duration-and-easing-curve).