### PR TITLE
Fix positioning of w-full-last-children in .outer-grid

### DIFF
--- a/tailwind.config.peak.js
+++ b/tailwind.config.peak.js
@@ -115,8 +115,8 @@ module.exports = {
           // If the last child of the outer grid is full width (e.g. when it has a full width 
           // colored background), give it negative margin bottom to get it flush to your 
           // sites footer.
-          '& > *:last-child:has(.w-full)': {
-            marginBottom: theme('spacing.12') * -1,
+          '& > *:last-child.w-full': {
+            marginBottom: `-${theme('spacing.12')}`,
           },
         },
         [`@media (min-width: ${theme('screens.md')})`]: {
@@ -125,8 +125,8 @@ module.exports = {
             rowGap: theme('spacing.16'),
             paddingTop: theme('spacing.16'),
             paddingBottom: theme('spacing.16'),
-            '& > *:last-child:has(.w-full)': {
-              marginBottom: theme('spacing.16') * -1,
+            '& > *:last-child.w-full': {
+              marginBottom: `-${theme('spacing.16')}`,
             },
           },
         },
@@ -142,8 +142,8 @@ module.exports = {
             rowGap: theme('spacing.24'),
             paddingTop: theme('spacing.24'),
             paddingBottom: theme('spacing.24'),
-            '& > *:last-child:has(.w-full)': {
-              marginBottom: theme('spacing.24') * -1,
+            '& > *:last-child.w-full': {
+              marginBottom: `-${theme('spacing.24')}`,
             },
           },
         },


### PR DESCRIPTION
As discussed on Discord, there's an issue with correctly removing the bottom spacing of full-width last-children wrapped in `.outer-grid`.

Original message in discord attached.

--------

hi guys, just found an issue with the outer-grid last-child selector for full width elements.

`'& > *:last-child:has(.w-full)': {
  marginBottom: theme('spacing.24') * -1,
}`

two things going on here: i would probably expect something like this to work:

```
 <div class="outer-grid">
  <section>Not full width, has spacing</section>
  <section>Not full width, has spacing</section>
  <section w-full>full width, no spacing below the section</section>
</div>
```

currently, this is obviously not expected behavior since :has applies to children only.

this is personal preference though :smile: what i actually see as needing to be fixed is the marginBottom calculation, since in this case, `theme(spacing.24')` will return an `rem` value, let's say `6rem`, which will break calculation (`NaN`)

when applied like this, it should be working fine for all use cases:
```marginBottom: `-${theme('spacing.24')}```


is this something useful in general, or is it just me? if yes, i'll create a PR :slight_smile:

thanks for the great starter!