### PR TITLE
Adding URL to the JSON Linked Data

### DIFF
--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -52,13 +52,15 @@
                 "@context": "http://schema.org",
                 "@type": "Organization",
                 "name": "{{ seo:organization_name }}",
-                "logo": "{{ permalink }}{{ glide:seo:organization_logo width='336' height='336' fit='crop_focal' }}",
+                "url": "{{ config:app:url }}{{ homepage }}",
+                "logo": "{{ permalink }}{{ glide:seo:organization_logo width='336' height='336' fit='crop_focal' }}"
             }
         {{ elseif seo:json_ld_type == 'person' }}
             {
                 "@context": "http://schema.org",
                 "@type": "Person",
-                "name": "{{ seo:person_name }}",
+                "url": "{{ config:app:url }}{{ homepage }}",
+                "name": "{{ seo:person_name }}"
             }
         {{ elseif seo:json_ld_type == 'custom' }}
             {{ seo:json_ld }}


### PR DESCRIPTION
Google's Structured data tester gave an error because:
- there was an trailing ,
- the lack of an URL entry 

This PR adds the URL and removes the comma.