### PR TITLE
Use fakerphp/faker instead of fzaninotto/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.5",
         "facade/ignition": "^2.3.6",
-        "fzaninotto/faker": "^1.9.1",
+        "fakerphp/faker": "^1.13.0",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3"


### PR DESCRIPTION
fzaninotto/faker is no longer maintained. For future releases I would recommend to use fakerphp/faker which I think is maintained by people from the laravel team.

This would also remove the warning while installing the composer dependencies:  
`Package fzaninotto/faker is abandoned, you should avoid using it. No replacement was suggested.`