### PR TITLE
Seperate compilation of utilities and custom CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ npm-debug.log
 yarn-error.log
 .DS_Store
 /public/css/site.css
+/public/css/theme.css
+/public/css/utilities.css
 /public/js/site.js
 /public/js/site.js.map
 /public/js/site.js.LICENSE.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 1.22.0 (unreleased)
+
+### What's new
+- Support for Statamic 3.1 white labeling.
+- Seperate compilation of Tailwind CSS so when you use and edit just `resources/css/site.css` to add custom CSS, compilation will be way faster.
+
+### What's improved
+- Disable `max-width` on `prose` class by default (as it's already in a container).
+
 ## 1.21.1 (2020-02-17)
 
 ### What's new

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Read up on the [Tailwind Forms](https://github.com/tailwindlabs/tailwindcss-form
 
 You can use a helper utility by adding the class `?` to quickly identify elements on screen. Original idea by [Gavin Joyce](https://github.com/GavinJoyce/tailwindcss-question-mark).
 
-> Note: if you don't want to define your custom CSS in Tailwind JS config files you can add it to `resources/css/custom.css`. Make sure to read up on the use of [@layer](https://tailwindcss.com/docs/functions-and-directives#layer) to instruct PurgeCSS. Use whatever method you prefer.
+> Note: if you don't want to define your custom CSS in Tailwind JS config files you can add it to `resources/css/custom.css`. Make sure to read up on the use of [@layer](https://tailwindcss.com/docs/functions-and-directives#layer) to instruct PurgeCSS. Use whatever method you prefer. Compilation is separated from the Tailwind utilities so it'll be blazingly fast.
 
 # Features
 ## Assets

--- a/resources/css/custom.css
+++ b/resources/css/custom.css
@@ -1,7 +1,7 @@
 /* If you don't want to use the JS in CSS syntax from `tailwind.config.site.js` you can add your own custom CSS here. Use different layers to make sure your CSS either get's purged or not: https://tailwindcss.com/docs/functions-and-directives#layer. CSS in the base layer won't get purged. */
 
 @layer base {
-
+    
 }
 
 @layer components {

--- a/resources/css/site.css
+++ b/resources/css/site.css
@@ -1,4 +1,0 @@
-@import "tailwindcss/base";
-@import "custom";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";

--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -1,0 +1,3 @@
+@import "tailwindcss/base";
+@import "custom";
+@import "tailwindcss/components";

--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -1,0 +1,1 @@
+@import "tailwindcss/utilities";

--- a/tailwind.config.typography.js
+++ b/tailwind.config.typography.js
@@ -15,6 +15,7 @@ module.exports = {
       typography: (theme) => ({
         DEFAULT: {
           css: {
+            maxWidth: 'none',
             color: theme('colors.neutral.800'),
             '[class~="lead"]': {
               color: theme('colors.neutral.800'),

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -3,13 +3,19 @@ const mix = require('laravel-mix')
 mix.js('resources/js/site.js', 'public/js/site.js')
     .sourceMaps(false)
 
-mix.postCss('resources/css/site.css', 'public/css/site.css', [
-    require('postcss-import'),
-    require('tailwindcss'),
-    require('postcss-nested'),
-    require('postcss-focus-visible'),
-    require('autoprefixer'),
-])
+mix.options({
+    postCss: [
+        require('postcss-import'),
+        require('tailwindcss'),
+        require('postcss-nested'),
+        require('postcss-focus-visible'),
+        require('autoprefixer'),
+    ], 
+})
+
+mix.postCss('resources/css/theme.css', 'public/css/theme.css')
+mix.postCss('resources/css/utilities.css', 'public/css/utilities.css')
+mix.combine(['./public/css/theme.css', './public/css/utilities.css'], 'public/css/site.css')
 
 mix.browserSync({
     proxy: process.env.APP_URL,

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,6 +13,7 @@ mix.options({
     ], 
 })
 
+// Separate compiliation steps so edits to just `resources/css/custom.css` will compile blazingly fast.
 mix.postCss('resources/css/theme.css', 'public/css/theme.css')
 mix.postCss('resources/css/utilities.css', 'public/css/utilities.css')
 mix.combine(['./public/css/theme.css', './public/css/utilities.css'], 'public/css/site.css')


### PR DESCRIPTION
**TLDR**: When you edit just `resources/css/custom.css` compilation times will go from 10 seconds to less than a second. 

In this PR I separate the CSS compilation in three steps:

- [x] theme.css (containing your custom css)
- [x] utilities.css (containing the Tailwind utilities)
- [x] combining the two resulting files

This way when you use `resources/css/custom.css` it will compile a lot faster when since all the Tailwind utilities don't have to be recompiled. 

Great idea by [William](https://github.com/Pixney-William)!