### PR TITLE
Adding alternates to the sitemap.xml

### DIFF
--- a/resources/views/sitemap/sitemap.antlers.html
+++ b/resources/views/sitemap/sitemap.antlers.html
@@ -5,6 +5,12 @@
         {{ collection from="{handle}" seo_noindex:isnt="true" }}
             <url>
                 <loc>{{ permalink }}</loc>
+                
+                {{ locales }}
+                    <xhtml:link rel="alternate" hreflang="{{locale:key}}" href="{{ permalink }}" />
+                {{ /locales }}
+                <xhtml:link rel="alternate" hreflang="x-default" href="{{ permalink }}" />
+                        
                 <lastmod>{{ updated_at format="Y-m-d"}}</lastmod>
                 <changefreq>{{ sitemap_change_frequency ? sitemap_change_frequency : 'weekly' }}</changefreq>
                 <priority>{{ sitemap_priority ? sitemap_priority : '0.5' }}</priority>


### PR DESCRIPTION
This PR adds multi-site alternates to the sitemap.xml according to [these](https://developers.google.com/search/docs/advanced/crawling/localized-versions?hl=en#expandable-3) specs and [hesesses](https://discord.com/channels/793146959635939329/793146959635939332/815554467981819934)

Could some verify this on a clean install as I only have old starterkits on my machine.
 