### PR TITLE
Refactor color system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Release Notes
 
-## Unreleased
+## 1.27.0 (2021-04-21)
 
 ### What's new
+- Revamped the default color config
 - Add the sizing utility to the pull quote set.
 
 ### What's improved
 - Add `@click.away` to subnav list instead of parent anchor to prevent accidentally closing the subnav.
-- Use padding in navigation links instead of spacing the items. Thanks [Daniel](https://github.com/klickreflex).
+- Fix focus styles in Safari for buttons and the search input.
 - Revert using `slug` instead of `title | slugify` for link blocks as we don't know if there is a `slug`.
 - Use `as` instead of `tag` to overrule typography partial tags. This is a little more natural: `{{ partial:typograph/h1 as="h2" }}`.
+- Use padding in navigation links instead of spacing the items. Thanks [Daniel](https://github.com/klickreflex).
 
 ### What's removed
 - The Tailwind highlight utility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.27.0 (2021-04-21)
 
 ### What's new
-- Revamped the default color config
+- Revamped the [default color config](https://github.com/studio1902/statamic-peak/pull/96).
 - Add the sizing utility to the pull quote set.
 
 ### What's improved

--- a/content/collections/pages/home.md
+++ b/content/collections/pages/home.md
@@ -1,18 +1,11 @@
 ---
 title: Home
 updated_by: 0099140b-7e75-4f28-a8f7-9ff4fec4e3a9
-updated_at: 1619008483
+updated_at: 1619010251
 seo_noindex: false
 seo_nofollow: false
 seo_canonical_type: entry
 sitemap_change_frequency: weekly
 sitemap_priority: 0.5
-page_builder:
-  -
-    title: asdsf
-    text: asdf
-    form: contact
-    type: form
-    enabled: true
 id: home
 ---

--- a/content/collections/pages/home.md
+++ b/content/collections/pages/home.md
@@ -1,11 +1,18 @@
 ---
 title: Home
 updated_by: 0099140b-7e75-4f28-a8f7-9ff4fec4e3a9
-updated_at: 1616794275
+updated_at: 1619008483
 seo_noindex: false
 seo_nofollow: false
 seo_canonical_type: entry
 sitemap_change_frequency: weekly
 sitemap_priority: 0.5
+page_builder:
+  -
+    title: asdsf
+    text: asdf
+    form: contact
+    type: form
+    enabled: true
 id: home
 ---

--- a/resources/views/components/_button.antlers.html
+++ b/resources/views/components/_button.antlers.html
@@ -5,10 +5,10 @@
         class="font-bold outline-none focus-visible:ring focus-visible:ring-offset-2 {{ class }}
             {{ if button_type == 'inline' }}
                 underline motion-safe:transition 
-                {{ inverted ? 'text-white focus-visible:ring-white' : 'text-primary-600 focus-visible:ring-primary-300' }}
+                {{ inverted ? 'text-white focus-visible:ring-white' : 'text-primary focus-visible:ring-primary' }}
             {{ else }}
                 inline-flex items-center py-3 px-4 border-2 leading-none uppercase tracking-widest text-sm no-underline select-none whitespace-nowrap motion-safe:transition
-                {{ inverted ? 'border-white text-white focus-visible:ring-white' : 'border-primary-600 text-primary-700 focus-visible:ring-primary-300' }}
+                {{ inverted ? 'border-white text-white focus-visible:ring-white' : 'border-primary text-primary focus-visible:ring-primary' }}
             {{ /if }}
         "
         {{ unless faux }}

--- a/resources/views/components/_button.antlers.html
+++ b/resources/views/components/_button.antlers.html
@@ -2,7 +2,7 @@
 {{ if label }}
     <{{ as or 'a' }}
         {{ attribute }}
-        class="font-bold outline-none focus-visible:ring focus-visible:ring-offset-2 {{ class }}
+        class="font-bold focus:outline-none focus-visible:ring focus-visible:ring-offset-2 {{ class }}
             {{ if button_type == 'inline' }}
                 underline motion-safe:transition 
                 {{ inverted ? 'text-white focus-visible:ring-white' : 'text-primary focus-visible:ring-primary' }}

--- a/resources/views/components/_cookie_banner.antlers.html
+++ b/resources/views/components/_cookie_banner.antlers.html
@@ -5,7 +5,7 @@
         x-init="(window.getCookie('cookie_consent_date') < '{{ seo:cookie_revoke_before format="Y-m-d" }}' ? window.eraseCookie('cookie_consent') : '')"
     {{ /if }}
     x-show="open"
-    class="fixed z-50 inset-x-0 bottom-0 bg-primary-700"
+    class="fixed z-50 inset-x-0 bottom-0 bg-primary"
     x-cloak
 >
     <div class="fluid-container flex flex-col md:flex-row md:items-center justify-between flex-wrap py-4 space-y-4 md:space-y-0 md:space-x-4">
@@ -22,7 +22,7 @@
             <button 
                 @click="open = false, window.setCookie('cookie_consent', '0', {{ seo:cookie_expiration_days }})"
                 type="button" 
-                class="text-sm font-bold text-primary-100"
+                class="text-sm font-bold text-primary"
             >
                 {{ trans:strings.cookie_deny }}
             </button>
@@ -30,7 +30,7 @@
             <button 
                 @click="open = false, window.setCookie('cookie_consent', true, {{ seo:cookie_expiration_days }}), window.setCookie('cookie_consent_date', '{{ now format="Y-m-d" }}', {{ seo:cookie_expiration_days }})"
                 type="button" 
-                class="px-4 py-2 bg-primary-200 text-sm font-bold text-primary-700"
+                class="px-4 py-2 bg-primary text-sm font-bold text-primary"
             >
                 {{ trans:strings.cookie_accept }}
             </button>

--- a/resources/views/components/_dark_mode_toggle.antlers.html
+++ b/resources/views/components/_dark_mode_toggle.antlers.html
@@ -31,7 +31,7 @@
             aria-label="{{ trans:strings.set_dark_mode }}"
             title="{{ trans:strings.set_dark_mode }}"
         >
-            {{ svg:moon class="w-5 h-5 text-gray-800 hover:text-primary stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
+            {{ svg:moon class="w-5 h-5 text-neutral hover:text-primary stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
         </button>
 
         <button 
@@ -43,7 +43,7 @@
             aria-label="{{ trans:strings.disable_dark_mode }}"
             title="{{ trans:strings.disable_dark_mode }}"
         >
-            {{ svg:sun class="w-5 h-5 text-gray-800 hover:text-primary stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
+            {{ svg:sun class="w-5 h-5 text-neutral hover:text-primary stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
         </button
     </li>
 {{ /section:dark_mode_toggle }}

--- a/resources/views/components/_dark_mode_toggle.antlers.html
+++ b/resources/views/components/_dark_mode_toggle.antlers.html
@@ -31,7 +31,7 @@
             aria-label="{{ trans:strings.set_dark_mode }}"
             title="{{ trans:strings.set_dark_mode }}"
         >
-            {{ svg:moon class="w-5 h-5 text-neutral-800 hover:text-primary-600 stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
+            {{ svg:moon class="w-5 h-5 text-gray-800 hover:text-primary stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
         </button>
 
         <button 
@@ -43,7 +43,7 @@
             aria-label="{{ trans:strings.disable_dark_mode }}"
             title="{{ trans:strings.disable_dark_mode }}"
         >
-            {{ svg:sun class="w-5 h-5 text-neutral-800 hover:text-primary-600 stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
+            {{ svg:sun class="w-5 h-5 text-gray-800 hover:text-primary stroke-current transition-colors overflow-visible" alt="" aria-hidden="true" }}
         </button
     </li>
 {{ /section:dark_mode_toggle }}

--- a/resources/views/components/_notification.antlers.html
+++ b/resources/views/components/_notification.antlers.html
@@ -3,22 +3,22 @@
     class="
         rounded border p-4 
         {{ if type == 'success'}}
-            bg-success-100 border-success-600
+            bg-green-100 border-green-600
         {{ elseif type == 'notice' }}
-            bg-notice-100 border-notice-600
+            bg-yellow-100 border-yellow-600
         {{ elseif type == 'error' }}
-            bg-error-100 border-error-600
+            bg-red-100 border-red-600
         {{ /if }} 
         {{ class }}
     ">
     <div class="flex">
         <div class="flex-shrink-0">
             {{ if type == "success" }}
-                {{ svg:success class="h-5 w-5 text-success-800 fill-current transition-colors" alt="" aria-hidden="true" }}
+                {{ svg:success class="h-5 w-5 text-green-800 fill-current transition-colors" alt="" aria-hidden="true" }}
             {{ elseif type == "notice" }}
-                {{ svg:notice class="h-5 w-5 text-notice-800 fill-current transition-colors" alt="" aria-hidden="true" }}
+                {{ svg:notice class="h-5 w-5 text-yellow-800 fill-current transition-colors" alt="" aria-hidden="true" }}
             {{ elseif type == "error" }}
-                {{ svg:error class="h-5 w-5 text-error-800 fill-current transition-colors" alt="" aria-hidden="true" }}
+                {{ svg:error class="h-5 w-5 text-red-800 fill-current transition-colors" alt="" aria-hidden="true" }}
             {{ /if }}
         </div>
         <div class="ml-3">
@@ -26,11 +26,11 @@
                 class="
                     text-sm leading-5 font-bold 
                     {{ if type == 'success' }}
-                        text-success-800
+                        text-green-800
                     {{ elseif type == 'notice' }}
-                        text-notice-800
+                        text-yellow-800
                     {{ elseif type == 'error' }}
-                        text-error-800
+                        text-red-800
                     {{ /if }}
                 " 
                 {{ attribute }}>

--- a/resources/views/components/_pagination.antlers.html
+++ b/resources/views/components/_pagination.antlers.html
@@ -15,13 +15,13 @@
         {{ /section:pagination }}
         <nav class="md:px-8 flex justify-center space-x-4">
             {{ if prev_page }}
-                <a class="text-primary-600" href="{{ prev_page }}">&laquo; {{ trans:strings.previous }}</a>
+                <a class="text-primary" href="{{ prev_page }}">&laquo; {{ trans:strings.previous }}</a>
             {{ else }}
                 <span>&laquo; {{ trans:strings.previous }}</span>
             {{ /if }}
             <span class="">{{ current_page }} {{ trans:strings.of }} {{ total_pages }}</span>
             {{ if next_page }}
-                <a class="text-primary-600" href="{{ next_page }}">{{ trans:strings.next }} &raquo;</a>
+                <a class="text-primary" href="{{ next_page }}">{{ trans:strings.next }} &raquo;</a>
             {{ else }}
                 <span>{{ trans:strings.next }} &raquo;</span>
             {{ /if }}

--- a/resources/views/components/_pull_quote.antlers.html
+++ b/resources/views/components/_pull_quote.antlers.html
@@ -1,10 +1,10 @@
 {{# A pull quote with an optional author. #}}
 <div class="size-{{ size }} my-4">   
-    <div class="p-0 m-0 text-primary-600 italic text-3xl leading-snug">
+    <div class="p-0 m-0 text-primary italic text-3xl leading-snug">
         {{ quote | nl2br }}
     </div>
     {{ if author }}
-        <span class="block mt-4 font-bold text-neutral-500">
+        <span class="block mt-4 font-bold text-gray-500">
             {{ author }}
         </span>
     {{ /if }}

--- a/resources/views/components/_pull_quote.antlers.html
+++ b/resources/views/components/_pull_quote.antlers.html
@@ -4,7 +4,7 @@
         {{ quote | nl2br }}
     </div>
     {{ if author }}
-        <span class="block mt-4 font-bold text-gray-500">
+        <span class="block mt-4 font-bold text-neutral">
             {{ author }}
         </span>
     {{ /if }}

--- a/resources/views/components/_search_form.antlers.html
+++ b/resources/views/components/_search_form.antlers.html
@@ -16,7 +16,7 @@
 >
     <button 
         x-on:click="{ open = !open, setTimeout(() => {$refs.input.focus()}, 200) }" 
-        class="text-neutral-800 hover:text-primary-600"
+        class="text-gray-800 hover:text-primary"
         aria-label="{{ trans:strings.search }}"
     >
         {{ svg:search class="w-5 h-5 fill-current transition-colors" alt="" aria-hidden="true" }}
@@ -29,7 +29,7 @@
     >
         <input 
             x-ref="input" 
-            class="w-52 h-full pr-10 rounded border-neutral-400 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" 
+            class="w-52 h-full pr-10 rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" 
             placeholder="{{ trans:strings.search }}" 
             type="text" 
             x-model="value"
@@ -37,7 +37,7 @@
             name="q" 
         />
         <button 
-            class="absolute inset-y-0 right-0 mr-2 flex items-center text-neutral-800 hover:text-primary-600"
+            class="absolute inset-y-0 right-0 mr-2 flex items-center text-gray-800 hover:text-primary"
             aria-label="{{ trans:strings.search }}"
             :disabled="value === 0"
             :class="{ 'opacity-25 cursor-default': value.length === 0, 'opacity-100': value.length > 0 }"

--- a/resources/views/components/_search_form.antlers.html
+++ b/resources/views/components/_search_form.antlers.html
@@ -16,7 +16,7 @@
 >
     <button 
         x-on:click="{ open = !open, setTimeout(() => {$refs.input.focus()}, 200) }" 
-        class="text-gray-800 hover:text-primary"
+        class="text-neutral hover:text-primary"
         aria-label="{{ trans:strings.search }}"
     >
         {{ svg:search class="w-5 h-5 fill-current transition-colors" alt="" aria-hidden="true" }}
@@ -29,7 +29,7 @@
     >
         <input 
             x-ref="input" 
-            class="w-52 h-full pr-10 rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" 
+            class="w-52 h-full pr-10 rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" 
             placeholder="{{ trans:strings.search }}" 
             type="text" 
             x-model="value"
@@ -37,7 +37,7 @@
             name="q" 
         />
         <button 
-            class="absolute inset-y-0 right-0 mr-2 flex items-center text-gray-800 hover:text-primary"
+            class="absolute inset-y-0 right-0 mr-2 flex items-center text-neutral hover:text-primary"
             aria-label="{{ trans:strings.search }}"
             :disabled="value === 0"
             :class="{ 'opacity-25 cursor-default': value.length === 0, 'opacity-100': value.length > 0 }"

--- a/resources/views/components/_table.antlers.html
+++ b/resources/views/components/_table.antlers.html
@@ -1,12 +1,12 @@
 {{# A sizeable table. #}}
 <div class="size-{{ size }} my-4 overflow-scroll">
-    <table class="w-full bg-light rounded-md shadow border-collapse overflow-hidden">
+    <table class="w-full bg-light border-collapse">
         {{ table }}
             {{ if first && first_row_headers }}
                 <thead>
                     <tr>
                         {{ cells }}
-                            <th class="px-3 xl:px-6 py-3 border-b border-gray-200 bg-gray-100 text-left text-xs font-bold text-gray-500 uppercase tracking-wider">{{ value }}</th>
+                            <th class="px-3 xl:px-6 py-3 border-b border-neutral bg-neutral text-left text-xs font-bold text-white uppercase tracking-wider">{{ value }}</th>
                         {{ /cells }}
                     </tr>
                 </thead>
@@ -21,9 +21,9 @@
                 <tr>
                     {{ cells }}
                         {{ if first && first_column_headers }}
-                            <th class="px-3 xl:px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs font-bold text-gray-500 uppercase tracking-wider">{{ value }}</th>
+                            <th class="px-3 xl:px-6 py-3 border-b border-neutral bg-neutral text-left text-xs font-bold text-white uppercase tracking-wider">{{ value }}</th>
                         {{ else }}
-                            <td class="px-3 xl:px-6 py-3 whitespace-nowrap border-b border-gray-200 text-sm leading-3 text-gray-600">{{ value }}</td>
+                            <td class="px-3 xl:px-6 py-3 whitespace-nowrap border-b border-neutral text-sm leading-3 text-neutral">{{ value }}</td>
                         {{ /if }}
                     {{ /cells }}
                 </tr>

--- a/resources/views/components/_table.antlers.html
+++ b/resources/views/components/_table.antlers.html
@@ -6,7 +6,7 @@
                 <thead>
                     <tr>
                         {{ cells }}
-                            <th class="px-3 xl:px-6 py-3 border-b border-neutral-200 bg-neutral-100 text-left text-xs font-bold text-neutral-500 uppercase tracking-wider">{{ value }}</th>
+                            <th class="px-3 xl:px-6 py-3 border-b border-gray-200 bg-gray-100 text-left text-xs font-bold text-gray-500 uppercase tracking-wider">{{ value }}</th>
                         {{ /cells }}
                     </tr>
                 </thead>
@@ -21,9 +21,9 @@
                 <tr>
                     {{ cells }}
                         {{ if first && first_column_headers }}
-                            <th class="px-3 xl:px-6 py-3 border-b border-neutral-200 bg-neutral-50 text-left text-xs font-bold text-neutral-500 uppercase tracking-wider">{{ value }}</th>
+                            <th class="px-3 xl:px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs font-bold text-gray-500 uppercase tracking-wider">{{ value }}</th>
                         {{ else }}
-                            <td class="px-3 xl:px-6 py-3 whitespace-nowrap border-b border-neutral-200 text-sm leading-3 text-neutral-600">{{ value }}</td>
+                            <td class="px-3 xl:px-6 py-3 whitespace-nowrap border-b border-gray-200 text-sm leading-3 text-gray-600">{{ value }}</td>
                         {{ /if }}
                     {{ /cells }}
                 </tr>

--- a/resources/views/components/_toolbar.antlers.html
+++ b/resources/views/components/_toolbar.antlers.html
@@ -6,14 +6,14 @@
         x-cloak
     >
         {{ if environment == 'local' }}
-            <span title="Current Tailwind breakpoint" class="flex items-center p-2 space-x-1 text-notice-800 bg-notice-200">
+            <span title="Current Tailwind breakpoint" class="flex items-center p-2 space-x-1 text-yellow-800 bg-yellow-200">
                 {{ svg:breakpoint class="w-4 h-4 fill-current" alt="" aria-hidden="true" }}
                 <span class="breakpoint"></span>
             </span>
         {{ /if }}
 
         {{ if logged_in == true }}
-            <a href="{{ edit_url }}" title="Edit entry in CP" aria-label="Edit entry in CP" target="_blank" class="flex items-center p-2 space-x-1 text-neutral-800 bg-neutral-200 hover:bg-neutral-300">
+            <a href="{{ edit_url }}" title="Edit entry in CP" aria-label="Edit entry in CP" target="_blank" class="flex items-center p-2 space-x-1 text-gray-800 bg-gray-200 hover:bg-gray-300">
                 {{ svg:edit class="w-4 h-4 fill-current" alt="" aria-hidden="true" }}
                 <span>Edit</span>
             </a>
@@ -21,7 +21,7 @@
 
         <button 
             @click="visible = !visible, visible ? window.setCookie('toolbar_visible', true) : window.setCookie('toolbar_visible', false)"
-            title="Toggle toolbar visibility" aria-label="Toggle toolbar visibility" class="flex items-center justify-center px-2 bg-neutral-200 hover:bg-neutral-300"
+            title="Toggle toolbar visibility" aria-label="Toggle toolbar visibility" class="flex items-center justify-center px-2 bg-gray-200 hover:bg-gray-300"
         >
             <div :class="{ 'hidden': visible, 'block': !visible }">
                 {{ svg:invisible class="w-5 h-5 fill-current" alt="" aria-hidden="true" }}

--- a/resources/views/navigation/_breadcrumbs.antlers.html
+++ b/resources/views/navigation/_breadcrumbs.antlers.html
@@ -2,7 +2,7 @@
 <ul class="flex">
     {{ nav:breadcrumbs }}
         <li class="flex">
-            <a class="{{ if is_current }}text-primary-600{{ /if }}" href="{{ url }}">{{ title }}</a>
+            <a class="{{ if is_current }}text-primary{{ /if }}" href="{{ url }}">{{ title }}</a>
             <span class="px-2">{{ unless last }}>{{ /unless }}</span>
         </li>
     {{ /nav:breadcrumbs }}

--- a/resources/views/navigation/_main.antlers.html
+++ b/resources/views/navigation/_main.antlers.html
@@ -11,7 +11,7 @@
                 class="relative leading-none"
             >
                 <a
-                    class="flex items-center font-bold text-xs uppercase tracking-wide hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
+                    class="flex items-center font-bold text-xs uppercase tracking-wide hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
                     {{ if children }}
                         href="#"
                         @click.prevent="subnavOpen = !subnavOpen"
@@ -21,7 +21,7 @@
                 >
                     {{ title }}
                     {{ if children }}
-                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-neutral-800"
+                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-gray-800"
                             :class="{ 'rotate-180': subnavOpen }"
                             aria-hidden="true"
                             stroke-width="16"
@@ -40,7 +40,7 @@
                         {{ children }}
                             <li class="">
                                 <a
-                                    class="whitespace-nowrap py-2 block text-xs font-bold hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
+                                    class="whitespace-nowrap py-2 block text-xs font-bold hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
                                     href="{{ url }}"
                                 >
                                     {{ title }}
@@ -58,7 +58,7 @@
 <nav class="md:hidden" x-data="{ mobileNavOpen: false }">
     <button
         @click.prevent="mobileNavOpen = !mobileNavOpen, mobileNavOpen ? document.body.classList.add('no-scroll') : document.body.classList.remove('no-scroll')"
-        class="fixed bottom-0 right-0 z-20 flex items-center justify-center w-16 h-16 mr-8 text-xs font-bold tracking-widest text-white mb-safe bg-primary-500 text-uppercase"
+        class="fixed bottom-0 right-0 z-20 flex items-center justify-center w-16 h-16 mr-8 text-xs font-bold tracking-widest text-white mb-safe bg-primary text-uppercase"
         aria-label="Toggle menu"
         x-text="mobileNavOpen ? '{{ trans:strings.close }}' : '{{ trans:strings.menu }}'"
     ></button>
@@ -76,7 +76,7 @@
                 class="leading-none"
             >
                 <a
-                    class="flex items-center font-bold uppercase tracking-wide hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
+                    class="flex items-center font-bold uppercase tracking-wide hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
                     {{ if children }}
                         href="#"
                         @click.prevent="mobileNavSubnavOpen = !mobileNavSubnavOpen"
@@ -87,7 +87,7 @@
                 >
                    {{ title }}
                    {{ if children }}
-                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-neutral-800"
+                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-gray-800"
                             :class="{ 'rotate-180': mobileNavSubnavOpen }"
                             aria-hidden="true"
                             stroke-width="16"
@@ -105,7 +105,7 @@
                         {{ children }}
                             <li>
                                 <a
-                                    class="whitespace-nowrap font-bold hover:text-primary-600 {{ is_current || is_parent ? 'text-primary-600' : 'text-neutral-800' }}"
+                                    class="whitespace-nowrap font-bold hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
                                     href="{{ url }}">
                                     {{ title }}
                                 </a>

--- a/resources/views/navigation/_main.antlers.html
+++ b/resources/views/navigation/_main.antlers.html
@@ -11,7 +11,7 @@
                 class="relative leading-none"
             >
                 <a
-                    class="flex items-center font-bold text-xs uppercase tracking-wide hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
+                    class="flex items-center font-bold text-xs uppercase tracking-wide hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-neutral' }}"
                     {{ if children }}
                         href="#"
                         @click.prevent="subnavOpen = !subnavOpen"
@@ -21,7 +21,7 @@
                 >
                     {{ title }}
                     {{ if children }}
-                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-gray-800"
+                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-neutral"
                             :class="{ 'rotate-180': subnavOpen }"
                             aria-hidden="true"
                             stroke-width="16"
@@ -40,7 +40,7 @@
                         {{ children }}
                             <li class="">
                                 <a
-                                    class="whitespace-nowrap py-2 block text-xs font-bold hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
+                                    class="whitespace-nowrap py-2 block text-xs font-bold hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-neutral' }}"
                                     href="{{ url }}"
                                 >
                                     {{ title }}
@@ -51,6 +51,7 @@
                 {{ /if }}
             </li>
         {{ /nav:main }}
+        {{ partial:components/search_form }}
     </ul>
 </nav>
 
@@ -76,7 +77,7 @@
                 class="leading-none"
             >
                 <a
-                    class="flex items-center font-bold uppercase tracking-wide hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
+                    class="flex items-center font-bold uppercase tracking-wide hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-neutral' }}"
                     {{ if children }}
                         href="#"
                         @click.prevent="mobileNavSubnavOpen = !mobileNavSubnavOpen"
@@ -87,7 +88,7 @@
                 >
                    {{ title }}
                    {{ if children }}
-                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-gray-800"
+                        <svg class="w-2 ml-1 overflow-visible transform stroke-current text-neutral"
                             :class="{ 'rotate-180': mobileNavSubnavOpen }"
                             aria-hidden="true"
                             stroke-width="16"
@@ -105,7 +106,7 @@
                         {{ children }}
                             <li>
                                 <a
-                                    class="whitespace-nowrap font-bold hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-gray-800' }}"
+                                    class="whitespace-nowrap font-bold hover:text-primary {{ is_current || is_parent ? 'text-primary' : 'text-neutral' }}"
                                     href="{{ url }}">
                                     {{ title }}
                                 </a>

--- a/resources/views/navigation/_main.antlers.html
+++ b/resources/views/navigation/_main.antlers.html
@@ -51,7 +51,6 @@
                 {{ /if }}
             </li>
         {{ /nav:main }}
-        {{ partial:components/search_form }}
     </ul>
 </nav>
 

--- a/resources/views/page_builder/_collection.antlers.html
+++ b/resources/views/page_builder/_collection.antlers.html
@@ -5,7 +5,7 @@
         <ul class="list-inside list-disc">
             {{ block:collection }}
                 <li>
-                    <a class="text-primary-600 underline" href="{{ url }}">
+                    <a class="text-primary underline" href="{{ url }}">
                         {{ title }}
                     </a>
                 </li>

--- a/resources/views/page_builder/_form.antlers.html
+++ b/resources/views/page_builder/_form.antlers.html
@@ -15,7 +15,7 @@
             <div class="w-full grid md:grid-cols-12 gap-y-6 md:gap-x-6">
                 {{# Honeypot spam protection. #}}
                 <div class="hidden">
-                    <label class="font-bold" for="{{ honeypot }}">{{ trans:strings.form_honeypot }} <sup class="text-notice-400">*</sup></label>
+                    <label class="font-bold" for="{{ honeypot }}">{{ trans:strings.form_honeypot }} <sup class="text-yellow-400">*</sup></label>
                     <input class="form-input w-full" id="{{ honeypot }}" type="text" name="{{ honeypot }}" tabindex="-1" autocomplete="off"/>
                 </div>
 
@@ -28,7 +28,7 @@
                         {{ width == '75' ?= 'md:col-span-9' }}
                         {{ width == '100' ?= 'md:col-span-12' }}"
                     >
-                        <label class="font-bold" for="{{ handle }}">{{ trans key="{display}" }} {{ if validate | contains:required }}<sup class="text-notice-400">*</sup>{{ /if }}</label>
+                        <label class="font-bold" for="{{ handle }}">{{ trans key="{display}" }} {{ if validate | contains:required }}<sup class="text-yellow-400">*</sup>{{ /if }}</label>
                         {{# Load notification when there is a validation error with the name field. #}}
                         <template x-if="errors.{{ handle }}">
                             {{ partial src="components/notification" type="error" attribute="x-text='errors.{handle}'" }}

--- a/resources/views/search.antlers.html
+++ b/resources/views/search.antlers.html
@@ -8,7 +8,7 @@
         <form class="relative col-span-12 md:col-span-8 md:col-start-3" action="/search">
             <input class="w-full pr-10 rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition"" placeholder="{{ trans:strings.search }}" type="text" value="{{ get:q }}" name="q"/>
 
-            <button class="absolute inset-y-0 right-0 flex mr-1 items-center text-neutral hover:text-primary rounded outline-none focus:outline-none focus-visible:ring-2 ring-secondary ring-offset-4 ring-offset-white" aria-label="{{ trans:strings.search }}">
+            <button class="absolute inset-y-0 right-0 flex mr-1 items-center text-neutral hover:text-primary rounded focus:outline-none focus-visible:ring-2 ring-secondary ring-offset-4 ring-offset-white" aria-label="{{ trans:strings.search }}">
                 {{ svg:search class="w-5 h-5 fill-current transition-colors" alt="" aria-hidden="true" }}
             </button>
         </form>

--- a/resources/views/search.antlers.html
+++ b/resources/views/search.antlers.html
@@ -6,9 +6,9 @@
         </div>
 
         <form class="relative col-span-12 md:col-span-8 md:col-start-3" action="/search">
-            <input class="w-full pr-10 rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition"" placeholder="{{ trans:strings.search }}" type="text" value="{{ get:q }}" name="q"/>
+            <input class="w-full pr-10 rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition"" placeholder="{{ trans:strings.search }}" type="text" value="{{ get:q }}" name="q"/>
 
-            <button class="absolute inset-y-0 right-0 flex mr-1 items-center text-gray-500 hover:text-primary rounded outline-none focus:outline-none focus-visible:ring-2 ring-secondary-600 ring-offset-4 ring-offset-white" aria-label="{{ trans:strings.search }}">
+            <button class="absolute inset-y-0 right-0 flex mr-1 items-center text-neutral hover:text-primary rounded outline-none focus:outline-none focus-visible:ring-2 ring-secondary ring-offset-4 ring-offset-white" aria-label="{{ trans:strings.search }}">
                 {{ svg:search class="w-5 h-5 fill-current transition-colors" alt="" aria-hidden="true" }}
             </button>
         </form>
@@ -21,7 +21,7 @@
             {{ else }}
                 <article class="col-span-12 md:col-span-8 md:col-start-3">
                     <a class="flex flex-col" href="{{ url }}">
-                        <span class="text-gray-500">{{ permalink }}</span>
+                        <span class="text-neutral">{{ permalink }}</span>
                         
                         {{ partial:typography/h2 class="mt-0" color="text-primary" :content="title" }}
                     </a>

--- a/resources/views/search.antlers.html
+++ b/resources/views/search.antlers.html
@@ -6,9 +6,9 @@
         </div>
 
         <form class="relative col-span-12 md:col-span-8 md:col-start-3" action="/search">
-            <input class="w-full pr-10 rounded border-neutral-400 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition"" placeholder="{{ trans:strings.search }}" type="text" value="{{ get:q }}" name="q"/>
+            <input class="w-full pr-10 rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition"" placeholder="{{ trans:strings.search }}" type="text" value="{{ get:q }}" name="q"/>
 
-            <button class="absolute inset-y-0 right-0 flex mr-1 items-center text-neutral-500 hover:text-primary-500 rounded outline-none focus:outline-none focus-visible:ring-2 ring-secondary-600 ring-offset-4 ring-offset-white" aria-label="{{ trans:strings.search }}">
+            <button class="absolute inset-y-0 right-0 flex mr-1 items-center text-gray-500 hover:text-primary rounded outline-none focus:outline-none focus-visible:ring-2 ring-secondary-600 ring-offset-4 ring-offset-white" aria-label="{{ trans:strings.search }}">
                 {{ svg:search class="w-5 h-5 fill-current transition-colors" alt="" aria-hidden="true" }}
             </button>
         </form>
@@ -21,9 +21,9 @@
             {{ else }}
                 <article class="col-span-12 md:col-span-8 md:col-start-3">
                     <a class="flex flex-col" href="{{ url }}">
-                        <span class="text-neutral-500">{{ permalink }}</span>
+                        <span class="text-gray-500">{{ permalink }}</span>
                         
-                        {{ partial:typography/h2 class="mt-0" color="text-primary-600" :content="title" }}
+                        {{ partial:typography/h2 class="mt-0" color="text-primary" :content="title" }}
                     </a>
                     <p>
                         {{# Sow the SEO meta description if available. #}}

--- a/resources/views/typography/_caption.antlers.html
+++ b/resources/views/typography/_caption.antlers.html
@@ -1,5 +1,5 @@
 {{ if caption }}
-    <{{ as or 'span' }} class="mt-2 text-gray-500 text-sm">
+    <{{ as or 'span' }} class="mt-2 text-neutral text-sm">
         {{ caption }}
     </{{ as or 'span' }}>
 {{ /if }}

--- a/resources/views/typography/_caption.antlers.html
+++ b/resources/views/typography/_caption.antlers.html
@@ -1,5 +1,5 @@
 {{ if caption }}
-    <{{ as or 'span' }} class="mt-2 text-neutral-500 text-sm">
+    <{{ as or 'span' }} class="mt-2 text-gray-500 text-sm">
         {{ caption }}
     </{{ as or 'span' }}>
 {{ /if }}

--- a/resources/views/typography/_h1.antlers.html
+++ b/resources/views/typography/_h1.antlers.html
@@ -1,2 +1,2 @@
 {{# Typography h1 partial with class, tag, color and content attributes. #}}
-<{{ as or 'h1' }} class="text-2xl md:text-4xl font-bold leading-tight {{ color or 'text-neutral-900' }} {{ class }}">{{ content | nl2br }}</{{ as or 'h1' }}>
+<{{ as or 'h1' }} class="text-2xl md:text-4xl font-bold leading-tight {{ color or 'text-gray-900' }} {{ class }}">{{ content | nl2br }}</{{ as or 'h1' }}>

--- a/resources/views/typography/_h1.antlers.html
+++ b/resources/views/typography/_h1.antlers.html
@@ -1,2 +1,2 @@
 {{# Typography h1 partial with class, tag, color and content attributes. #}}
-<{{ as or 'h1' }} class="text-2xl md:text-4xl font-bold leading-tight {{ color or 'text-gray-900' }} {{ class }}">{{ content | nl2br }}</{{ as or 'h1' }}>
+<{{ as or 'h1' }} class="text-2xl md:text-4xl font-bold leading-tight {{ color or 'text-neutral' }} {{ class }}">{{ content | nl2br }}</{{ as or 'h1' }}>

--- a/resources/views/vendor/statamic/forms/fields/checkboxes.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/checkboxes.antlers.html
@@ -1,7 +1,7 @@
 <div class="flex {{ inline ? 'space-x-4' : 'flex-col space-y-4' }}">
     {{ foreach:options as="value|label" }}
         <label class="inline-flex items-center">
-            <input class="mr-2 rounded border-neutral-400 text-primary-600 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" type="checkbox" name="{{ handle }}[]" value="{{ value }}" {{ if (old | in_array:value) }}checked{{ /if }}>
+            <input class="mr-2 rounded border-gray-400 text-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" type="checkbox" name="{{ handle }}[]" value="{{ value }}" {{ if (old | in_array:value) }}checked{{ /if }}>
             {{ trans key="{ label }" }}
         </label>
     {{ /foreach:options }}

--- a/resources/views/vendor/statamic/forms/fields/checkboxes.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/checkboxes.antlers.html
@@ -1,7 +1,7 @@
 <div class="flex {{ inline ? 'space-x-4' : 'flex-col space-y-4' }}">
     {{ foreach:options as="value|label" }}
         <label class="inline-flex items-center">
-            <input class="mr-2 rounded border-gray-400 text-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" type="checkbox" name="{{ handle }}[]" value="{{ value }}" {{ if (old | in_array:value) }}checked{{ /if }}>
+            <input class="mr-2 rounded border-neutral text-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" type="checkbox" name="{{ handle }}[]" value="{{ value }}" {{ if (old | in_array:value) }}checked{{ /if }}>
             {{ trans key="{ label }" }}
         </label>
     {{ /foreach:options }}

--- a/resources/views/vendor/statamic/forms/fields/default.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/default.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
+<input class="w-full rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="{{ input_type ?? 'text' }}" 

--- a/resources/views/vendor/statamic/forms/fields/default.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/default.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full rounded border-neutral-400 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" :class="{ 'border-error-600 focus-visible:border-error-600': errors.{{ handle }} }"
+<input class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="{{ input_type ?? 'text' }}" 

--- a/resources/views/vendor/statamic/forms/fields/integer.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/integer.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full rounded border-neutral-400 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" :class="{ 'border-error-600 focus-visible:border-error-600': errors.{{ handle }} }"
+<input class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="number" 

--- a/resources/views/vendor/statamic/forms/fields/integer.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/integer.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
+<input class="w-full rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="number" 

--- a/resources/views/vendor/statamic/forms/fields/radio.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/radio.antlers.html
@@ -1,7 +1,7 @@
 <div class="flex {{ inline ? 'space-x-4' : 'flex-col space-y-4' }}">
     {{ foreach:options as="value|label" }}
         <label class="inline-flex items-center">
-            <input class="mr-2 border-neutral-400 text-primary-600 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" type="radio" name="{{ handle }}" value="{{ value }}" {{ old === value ?= "checked" }}>
+            <input class="mr-2 border-gray-400 text-primary focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" type="radio" name="{{ handle }}" value="{{ value }}" {{ old === value ?= "checked" }}>
             {{ trans key="{ label }" }}
         </label>
     {{ /foreach:options }}

--- a/resources/views/vendor/statamic/forms/fields/radio.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/radio.antlers.html
@@ -1,7 +1,7 @@
 <div class="flex {{ inline ? 'space-x-4' : 'flex-col space-y-4' }}">
     {{ foreach:options as="value|label" }}
         <label class="inline-flex items-center">
-            <input class="mr-2 border-gray-400 text-primary focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" type="radio" name="{{ handle }}" value="{{ value }}" {{ old === value ?= "checked" }}>
+            <input class="mr-2 border-neutral text-primary focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" type="radio" name="{{ handle }}" value="{{ value }}" {{ old === value ?= "checked" }}>
             {{ trans key="{ label }" }}
         </label>
     {{ /foreach:options }}

--- a/resources/views/vendor/statamic/forms/fields/select.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/select.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<select class="w-full rounded border-neutral-400 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" name="{{ handle }}{{ multiple ?= "[]" }}" {{ multiple ?= "multiple" }} :class="{ 'border-error-600 focus-visible:border-error-600': errors.{{ handle }} }">
+<select class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" name="{{ handle }}{{ multiple ?= "[]" }}" {{ multiple ?= "multiple" }} :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }">
     {{ unless multiple }}
         <option value>{{ trans key="Please select..." }}</option>
     {{ /unless }}

--- a/resources/views/vendor/statamic/forms/fields/select.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/select.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<select class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" name="{{ handle }}{{ multiple ?= "[]" }}" {{ multiple ?= "multiple" }} :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }">
+<select class="w-full rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" name="{{ handle }}{{ multiple ?= "[]" }}" {{ multiple ?= "multiple" }} :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }">
     {{ unless multiple }}
         <option value>{{ trans key="Please select..." }}</option>
     {{ /unless }}

--- a/resources/views/vendor/statamic/forms/fields/text.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/text.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
+<input class="w-full rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="{{ input_type ?? 'text' }}" 

--- a/resources/views/vendor/statamic/forms/fields/text.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/text.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<input class="w-full rounded border-neutral-400 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" :class="{ 'border-error-600 focus-visible:border-error-600': errors.{{ handle }} }"
+<input class="w-full rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}"
     type="{{ input_type ?? 'text' }}" 

--- a/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<textarea class="w-full h-32 rounded border-neutral-400 focus-visible:border-primary-300 focus-visible:ring focus-visible:ring-primary-300 motion-safe:transition" :class="{ 'border-error-600 focus-visible:border-error-600': errors.{{ handle }} }"
+<textarea class="w-full h-32 rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}" 
     rows="5"

--- a/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
@@ -1,5 +1,5 @@
 {{# Bind custom error classses when there is a validation error with the field. #}}
-<textarea class="w-full h-32 rounded border-gray-400 focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
+<textarea class="w-full h-32 rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" :class="{ 'border-red-600 focus-visible:border-red-600': errors.{{ handle }} }"
     id="{{ handle }}" 
     name="{{ handle }}" 
     rows="5"

--- a/tailwind.config.peak.js
+++ b/tailwind.config.peak.js
@@ -13,12 +13,14 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        // Error styling colors (currently default TW Red).
-        error: colors.red,
-        // Notice styling colors (currently default TW Amber).
-        notice: colors.amber,
-        // Success styling colors (currently default TW Amber).
-        success: colors.green,
+        // Gray colors.
+        gray: colors.blueGray,
+        // Error styling colors.
+        red: colors.red,
+        // Notice styling colors.
+        yellow: colors.amber,
+        // Success styling colors.
+        green: colors.green,
       },
       spacing: {
         // Used for the mobile navigation toggle.

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -20,7 +20,7 @@ module.exports = {
       white:  '#fff',
       // Neutrals: neutral colors, with a default fallback if you don't need shades.
       neutral: { 
-        DEFAULT: colors.blueGray['600'],
+        DEFAULT: colors.blueGray['800'],
         ...colors.blueGray
       },
       // Primary: primary brand color with a default fallback if you don't need shades.
@@ -70,7 +70,7 @@ module.exports = {
         },
         'html': {
             fontDisplay: 'swap',
-            color: theme('colors.neutral.800'),
+            color: theme('colors.neutral.DEFAULT'),
             //--------------------------------------------------------------------------
             // Set sans, serif or mono stack with optional custom font as default.
             //--------------------------------------------------------------------------
@@ -79,11 +79,11 @@ module.exports = {
             // fontFamily: theme('fontFamily.serif'),
         },
         '::selection': {
-            backgroundColor: theme('colors.primary.600'),
+            backgroundColor: theme('colors.primary.DEFAULT'),
             color: theme('colors.white'),
         },
         '::-moz-selection': {
-            backgroundColor: theme('colors.primary.600'),
+            backgroundColor: theme('colors.primary.DEFAULT'),
             color: theme('colors.white'),
         },
       })

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -18,13 +18,12 @@ module.exports = {
       transparent: 'transparent',
       black:   '#000',
       white:  '#fff',
-      // Neutrals (currently default TW blue gray).
+      // Neutrals: neutral colors, with a default fallback if you don't need shades.
       neutral: { 
         DEFAULT: colors.blueGray['600'],
         ...colors.blueGray
       },
-      // Client primary color (currently default TW blue).
-      // This is the color set you usually change for each project with brand color shades.
+      // Primary: primary brand color with a default fallback if you don't need shades.
       primary: { 
         DEFAULT: colors.blue['600'],
         ...colors.blue

--- a/tailwind.config.site.js
+++ b/tailwind.config.site.js
@@ -18,12 +18,12 @@ module.exports = {
       transparent: 'transparent',
       black:   '#000',
       white:  '#fff',
-      // Neutrals: neutral colors, with a default fallback if you don't need shades.
+      // Neutrals: neutral colors, with a default fallback if you don't need shades. Always set a DEFAULT if you use shades.
       neutral: { 
         DEFAULT: colors.blueGray['800'],
         ...colors.blueGray
       },
-      // Primary: primary brand color with a default fallback if you don't need shades.
+      // Primary: primary brand color with a default fallback if you don't need shades. Always set a DEFAULT if you use shades.
       primary: { 
         DEFAULT: colors.blue['600'],
         ...colors.blue

--- a/tailwind.config.typography.js
+++ b/tailwind.config.typography.js
@@ -15,33 +15,33 @@ module.exports = {
       typography: (theme) => ({
         DEFAULT: {
           css: {
-            color: theme('colors.neutral.800'),
+            color: theme('colors.neutral.DEFAULT'),
             '[class~="lead"]': {
-              color: theme('colors.neutral.800'),
+              color: theme('colors.neutral.DEFAULT'),
             },
             a: {
-              color: theme('colors.primary.600'),
+              color: theme('colors.primary.DEFAULT'),
               '&:hover': {
-                color: theme('colors.primary.800'),
+                color: theme('colors.primary.DEFAULT'),
               },
             },
             'a.no-underline': {
               textDecoration: 'none',
             },
             'h1, h2, h3, h4': {
-              color: theme('colors.neutral.900'),
+              color: theme('colors.neutral.DEFAULT'),
             },
             blockquote: {
-              borderColor: theme('colors.primary.200'),
+              borderColor: theme('colors.primary.DEFAULT'),
             },
             hr: {
-              borderColor: theme('colors.neutral.100'), 
+              borderColor: theme('colors.neutral.DEFAULT'), 
             },
             'ul > li::before': { 
-              backgroundColor: theme('colors.neutral.500'),
+              backgroundColor: theme('colors.neutral.DEFAULT'),
             },
             'ol > li::before': { 
-              color: theme('colors.neutral.500'),
+              color: theme('colors.neutral.DEFAULT'),
             },
             'ul > li p, ol > li p': { 
               marginTop: '0em !important',


### PR DESCRIPTION
Support the following use cases by default:

1. Having color shades for all brand colors.
2. Having no color shades but just a few brand colors.

Things I changed:

- Neutral and primary now have a `DEFAULT` color you can assign in `tailwind.config.site.js`.
- Peak colors are now literal and defined in `tailwind.config.peak.js`. We have both `neutral` (brand) and `gray` (for the toolbar for example) now.
- All neutral and primary colors utilities in the templates just use the default color by using `text-primary` instead of `text-primary-600` for example. 

This makes Peak more ugly by default but that's a good thing I think. You should update colors, depending on the design, by hand anyways since it's not a kit you should use in production without a proper design. 