### PR TITLE
Fixed asset tag to get twitter_image

### DIFF
--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -127,7 +127,7 @@
     {{ /if }}
     {{ if twitter_image }}
         <meta name="twitter:image" content="{{ glide:twitter_image width='1200' height='600' fit='crop_focal' absolute="true" }}">
-        {{ asset :url="twitter_image:alt" }}
+        {{ asset :url="twitter_image" }}
             {{ if alt }}
                 <meta name="twitter:image:alt" content="{{ alt ensure_right='.' }}">
             {{ /if }}


### PR DESCRIPTION
Attempting to get the asset like `{{ asset :url="twitter_image:alt" }}` but since `alt` is not an image, the `<meta name="twitter:image:alt" ...` tag never gets displayed.

This change references the image URL, not the alt field.