### PR TITLE
Suggestion: keep quotes around font names with spaces

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -11,6 +11,10 @@ mix.postCss('resources/css/site.css', 'public/css/site.css', [
     require('autoprefixer'),
 ])
 
+mix.options({
+    cssNano: { minifyFontValues: false }
+});
+
 mix.browserSync({
     proxy: process.env.APP_URL,
     files: [


### PR DESCRIPTION
Not all browsers handle font names  with spaces properly, this keeps them there in the minified css file.