### PR TITLE
Added placeholders to the fields 'text' and 'textarea'

### DIFF
--- a/resources/views/vendor/statamic/forms/fields/text.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/text.antlers.html
@@ -5,6 +5,7 @@
     id="{{ handle }}"
     name="{{ handle }}"
     type="{{ input_type ?? 'text' }}"
+    placeholder="{{ placeholder }}"
     {{# Uncomment the following line if you want to use native browser validation first. #}}
     {{# {{ validate | contains:required ?= "required" }} #}}
     {{ old ?= value="{old}" }}

--- a/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/textarea.antlers.html
@@ -5,6 +5,7 @@
     id="{{ handle }}"
     name="{{ handle }}"
     rows="5"
+    placeholder="{{ placeholder }}"
     {{# Uncomment the following line if you want to use native browser validation first. #}}
     {{# {{ validate | contains:required ?= "required" }} #}}
 >{{ old }}</textarea>


### PR DESCRIPTION
The fields 'textarea' and 'text' both feature placeholder fields in backend, but don't use them in the template/frontend. This commit intends to correct this.