### PR TITLE
fix: exclude sitemap from static caching

### DIFF
--- a/config/statamic/static_caching.php
+++ b/config/statamic/static_caching.php
@@ -53,7 +53,7 @@ return [
     */
 
     'exclude' => [
-        //
+        '/sitemap.xml'
     ],
 
     /*


### PR DESCRIPTION
When static caching is used a "sitemap.xml_.html" is created. Together with the redirect rules in nginx or Apache this results in the sitemap.xml not being accessible (once cached).

This fix will remove the /sitemap.xml path from caching by adding the path to the exclude list in static_caching.php.

Alternatively one could add a dedicated rule in .htaccess that would prevent the routing to /static for sitemap.xml. However I think the approach via static_caching.php is closer to the Statamic way.