### PR TITLE
Add fallback-description to social-media image partial

### DIFF
--- a/resources/views/components/_social_image.antlers.html
+++ b/resources/views/components/_social_image.antlers.html
@@ -4,7 +4,11 @@
             {{ og_title ?? seo_title ?? title }}
         </h1>
         <p class="text-xl text-neutral leading-loose max-w-[40ch]">
-            {{ og_description ?? seo_description }}
+            {{ if og_description || seo_description }}
+                 {{ og_description ?? seo_description }}
+            {{ elseif seo:collection_defaults }}
+                 {{ partial:snippets/fallback_description }}
+            {{ /if }}
         </p>
         <div class="flex justify-end space-x-4">
             <img class="w-64 h-auto" src="https://cdn.studio1902.nl/assets/statamic-peak/statamic-peak-logo.svg"/>


### PR DESCRIPTION
I was just checking out the cool new stuff since I last used this starter kit. 🎉
As I found the fallback description a brilliant feature I found it to be missing in the social-image partial. (At least, I expected the same behavior there)
Not sure if this is the shortest way of expressing that functionality, though. 🤷🏼‍♂️