### PR TITLE
Use original mimetype for non-webp images

### DIFF
--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -29,11 +29,7 @@
                         {{ glide:url preset='xl' }} 1440w,
                         {{ glide:url preset='2xl' }} 1680w"
                     sizes="{{ sizes }}"
-                    {{ if extension == 'png' }}
-                        type="image/png"
-                    {{ else }}
-                        type="image/jpeg"
-                    {{ /if }}
+                    type="{{ image.mime_type }}"
                 >
                 <img
                     {{ if cover }}


### PR DESCRIPTION
Instead of checking for png images by extension and falling back to jpeg we can set the image's type attribute to the file's mime_type directly.