### PR TITLE
Set relative fallback font size and fix comment

### DIFF
--- a/tailwind.config.peak.js
+++ b/tailwind.config.peak.js
@@ -39,8 +39,8 @@ module.exports = {
     plugin(function({ addBase, theme }) {
       addBase({
         ':root': {
-          // Fluid typography from 1 rem to 1.15 rem with fallback to 16px.
-          fontSize: '16px',
+          // Fluid typography from 1 rem to 1.2 rem with fallback to 16px.
+          fontSize: '100%',
           'font-size': 'clamp(1rem, 1.6vw, 1.2rem)',
           // Safari resize fix.
           minHeight: '0vw',


### PR DESCRIPTION
The fallback root font size should not be absolute because this make preferred user-agent font size settings ineffective. For the vast majority of users 100% effectively creates a 16px root font size, but user who prefer larger type keep their preference.

Also the comment explaining the `clamp` part now matches the actual CSS to avoid confusion.