### PR TITLE
Add intrinsic image dimensions

### DIFF
--- a/dev/resources/views/components/_picture.antlers.html
+++ b/dev/resources/views/components/_picture.antlers.html
@@ -40,6 +40,8 @@
                     {{ /if }}
                     src="{{ glide:url preset='lg' }}"
                     alt="{{ alt ensure_right='.' }}"
+                    width="{{ image.width }}"
+                    height="{{ image.height }}"
                     {{ if lazy }}
                         loading="lazy"
                     {{ /if }}


### PR DESCRIPTION
This helps preventing CLS (culmulative layout shift), thus makes a better experience and higher page speed score.