### PR TITLE
Remove asset tag from picture partial for performance

### DIFF
--- a/dev/resources/views/components/_picture.antlers.html
+++ b/dev/resources/views/components/_picture.antlers.html
@@ -5,7 +5,7 @@
 
 {{ if image }}
     <picture>
-        {{ asset :url="image" }}
+        {{ image }}
             {{ if extension == 'svg' || extension == 'gif' }}
                 <img class="{{ class }}" src="{{ url }}" alt="{{ alt }}" />
             {{ else }}
@@ -47,6 +47,6 @@
                     {{ /if }}
                 >
             {{ /if }}
-        {{ /asset }}
+        {{ /image }}
     </picture>
 {{ /if }}


### PR DESCRIPTION
Fixes #158 .

Changes proposed in this pull request:
- Remove `asset` tag from picture partial.

Awaiting merge of https://github.com/statamic/cms/pull/4047 into Statamic.

Then we can remove the `asset` tag from the picture partial and you can do the following when you need to render multiple images from an array instead of one:

```
{{ images }}
  {{ partial:components/picture :image="self" }}
{{ /images }}
```

_Note to self_: add this information to https://peak.studio1902.nl/features/assets.html