### PR TITLE
Remove alt from social and favicon assets blueprint

### DIFF
--- a/dev/resources/blueprints/assets/favicons.yaml
+++ b/dev/resources/blueprints/assets/favicons.yaml
@@ -1,0 +1,4 @@
+sections:
+  main:
+    display: Main
+    fields: {  }

--- a/dev/resources/blueprints/assets/social_images.yaml
+++ b/dev/resources/blueprints/assets/social_images.yaml
@@ -1,0 +1,4 @@
+sections:
+  main:
+    display: Main
+    fields: {  }


### PR DESCRIPTION
Fixes #161  .

Changes proposed in this pull request:
- Add empty blueprints for `Social images` and `Favicon` asset containers.
