### PR TITLE
Update typo

### DIFF
--- a/docs/docs/features/forms.md
+++ b/docs/docs/features/forms.md
@@ -10,7 +10,7 @@ Peak renders forms and mail templates dynamically so you can add as many forms a
 * `resources/lang/en.json`. Strings file containing the the form's localizable field labels.
 * `resources/lang/en/strings.php` Strings file containing the e-mail's localizable body contents and logo image location.
 
-The default contact form has a required consent field. The fiels handle is `consent`. Due to restraints the form template contains a conditional that depens on this specific handle name. Don't use it for other form fields.
+The default contact form has a required consent field. The field handle is `consent`. Due to restraints the form template contains a conditional that depens on this specific handle name. Don't use it for other form fields.
 
 The forms sending is done with fetch and uses Alpine to display the various notifications.
 


### PR DESCRIPTION
Update basic type in `forms.md`

Changes proposed in this pull request:
- Update basic typo from `fiels` to `field`
