### PR TITLE
Add set command

### DIFF
--- a/dev/app/Console/Commands/AddSet.php
+++ b/dev/app/Console/Commands/AddSet.php
@@ -55,7 +55,7 @@ class AddSet extends Command
 
         try {
             $this->checkExistence('Fieldset', "resources/fieldsets/{$this->filename}.yaml");
-            $this->checkExistence('Partial', "resources/views/page_builder/_{$this->filename}.antlers.html");
+            $this->checkExistence('Partial', "resources/views/components/_{$this->filename}.antlers.html");
 
             $this->createFieldset();
             $this->createPartial();
@@ -64,7 +64,7 @@ class AddSet extends Command
             return $this->error($e->getMessage());
         }
 
-        $this->info("Peak page builder block '{$this->block_name}' added.");
+        $this->info("Peak page builder Article set '{$this->set_name}' added.");
     }
 
     /**
@@ -88,7 +88,7 @@ class AddSet extends Command
     {
         $stub = File::get(__DIR__.'/stubs/fieldset_set.yaml.stub');
         $contents = Str::of($stub)
-            ->replace('{{ name }}', $this->block_name);
+            ->replace('{{ name }}', $this->set_name);
 
         File::put(base_path("resources/fieldsets/{$this->filename}.yaml"), $contents);
     }
@@ -100,12 +100,12 @@ class AddSet extends Command
      */
     protected function createPartial()
     {
-        $stub = File::get(__DIR__.'/stubs/block.html.stub');
+        $stub = File::get(__DIR__.'/stubs/set.html.stub');
         $contents = Str::of($stub)
-            ->replace('{{ name }}', $this->block_name)
+            ->replace('{{ name }}', $this->set_name)
             ->replace('{{ filename }}', $this->filename);
 
-        File::put(base_path("resources/views/page_builder/_{$this->filename}.antlers.html"), $contents);
+        File::put(base_path("resources/views/components/_{$this->filename}.antlers.html"), $contents);
     }
 
     /**
@@ -115,10 +115,9 @@ class AddSet extends Command
      */
     protected function updatePageBuilder()
     {
-        $fieldset = Yaml::parseFile(base_path('resources/fieldsets/page_builder.yaml'));
+        $fieldset = Yaml::parseFile(base_path('resources/fieldsets/article.yaml'));
         $newSet = [
-            'display' => $this->block_name,
-            'instructions' => $this->instructions,
+            'display' => $this->set_name,
             'fields' => [
                 [
                     'import' => $this->filename
@@ -134,6 +133,6 @@ class AddSet extends Command
 
         Arr::set($fieldset, 'fields.0.field.sets', $existingSets);
 
-        File::put(base_path('resources/fieldsets/page_builder.yaml'), Yaml::dump($fieldset, 99, 2));
+        File::put(base_path('resources/fieldsets/article.yaml'), Yaml::dump($fieldset, 99, 2));
     }
 }

--- a/dev/app/Console/Commands/AddSet.php
+++ b/dev/app/Console/Commands/AddSet.php
@@ -11,7 +11,7 @@ use Statamic\Support\Arr;
 use Stringy\StaticStringy as Stringy;
 use Symfony\Component\Yaml\Yaml;
 
-class AddBlock extends Command
+class AddSet extends Command
 {
     use RunsInPlease;
 
@@ -20,35 +20,28 @@ class AddBlock extends Command
     *
     * @var string
     */
-    protected $name = 'peak:add-block';
+    protected $name = 'peak:add-set';
 
      /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = "Add a page builder block.";
+    protected $description = "Add an Article (Bard) set.";
 
      /**
-     * The block name.
+     * The set name.
      *
      * @var string
      */
-    protected $block_name = '';
+    protected $set_name = '';
 
      /**
-     * The block filename.
+     * The set filename.
      *
      * @var string
      */
     protected $filename = '';
-
-     /**
-     * The block instructions.
-     *
-     * @var string
-     */
-    protected $instructions = '';
 
      /**
      * Execute the console command.
@@ -57,9 +50,8 @@ class AddBlock extends Command
      */
     public function handle()
     {
-        $this->block_name = $this->ask('What should be the name for this block?');
-        $this->filename = Stringy::slugify($this->block_name, '_', Config::getShortLocale());
-        $this->instructions = $this->ask('What should be the instructions for this block?');
+        $this->set_name = $this->ask('What should be the name for this set?');
+        $this->filename = Stringy::slugify($this->set_name, '_', Config::getShortLocale());
 
         try {
             $this->checkExistence('Fieldset', "resources/fieldsets/{$this->filename}.yaml");
@@ -94,7 +86,7 @@ class AddBlock extends Command
      */
     protected function createFieldset()
     {
-        $stub = File::get(__DIR__.'/stubs/fieldset_block.yaml.stub');
+        $stub = File::get(__DIR__.'/stubs/fieldset_set.yaml.stub');
         $contents = Str::of($stub)
             ->replace('{{ name }}', $this->block_name);
 

--- a/dev/app/Console/Commands/stubs/fieldset.yaml.stub
+++ b/dev/app/Console/Commands/stubs/fieldset.yaml.stub
@@ -1,2 +1,0 @@
-title: {{ name }}
-fields: [ ]

--- a/dev/app/Console/Commands/stubs/fieldset_block.yaml.stub
+++ b/dev/app/Console/Commands/stubs/fieldset_block.yaml.stub
@@ -1,0 +1,2 @@
+title: '{{ name }}'
+fields: [ ]

--- a/dev/app/Console/Commands/stubs/fieldset_set.yaml.stub
+++ b/dev/app/Console/Commands/stubs/fieldset_set.yaml.stub
@@ -1,0 +1,7 @@
+title: '{{ name }}'
+fields:
+  -
+    handle: size
+    field: common.size
+    config:
+      instructions: 'The size in which the quote should be displayed.'

--- a/dev/app/Console/Commands/stubs/fieldset_set.yaml.stub
+++ b/dev/app/Console/Commands/stubs/fieldset_set.yaml.stub
@@ -4,4 +4,4 @@ fields:
     handle: size
     field: common.size
     config:
-      instructions: 'The size in which the quote should be displayed.'
+      instructions: 'The size in which the {{ name }} should be displayed.'

--- a/dev/app/Console/Commands/stubs/set.html.stub
+++ b/dev/app/Console/Commands/stubs/set.html.stub
@@ -1,0 +1,9 @@
+{{#
+	@name {{ name }}
+	@desc The {{ name }} component.
+    @set page.article.{{ filename }}
+#}}
+
+<div class="size-{{ size }} my-4">
+    <h2>🔧<br>{{ name }}</h2>
+</div>

--- a/dev/starter-kit.yaml
+++ b/dev/starter-kit.yaml
@@ -5,6 +5,7 @@ export_paths:
   - app/Console/Kernel.php
   - app/Console/Commands/AddBlock.php
   - app/Console/Commands/AddCollection.php
+  - app/Console/Commands/AddSet.php
   - app/Console/Commands/ClearSite.php
   - app/Console/Commands/stubs/block.html.stub
   - app/Console/Commands/stubs/collection_blueprint_private_dated.yaml.stub
@@ -12,8 +13,10 @@ export_paths:
   - app/Console/Commands/stubs/collection_blueprint_public_dated.yaml.stub
   - app/Console/Commands/stubs/collection_blueprint_public.yaml.stub
   - app/Console/Commands/stubs/collection.yaml.stub
-  - app/Console/Commands/stubs/fieldset.yaml.stub
+  - app/Console/Commands/stubs/fieldset_block.yaml.stub
+  - app/Console/Commands/stubs/fieldset_set.yaml.stub
   - app/Console/Commands/stubs/index.antlers.html.stub
+  - app/Console/Commands/stubs/set.html.stub
   - app/Console/Commands/stubs/show.antlers.html.stub
   - app/Http/Controllers/DynamicToken.php
   - app/Http/Middleware/VerifyCsrfToken.php


### PR DESCRIPTION
A command to add a set:

```bash
php please peak:add-set
```

This should:

- [x] Update the article.yaml fieldset.
- [x] Copy and fill a fieldset_set.yaml.stub
- [x] Copy and fill a set.html.stub
