### PR TITLE
Add new utilities for fill cascade and ltr/rtl

### DIFF
--- a/dev/tailwind.config.peak.js
+++ b/dev/tailwind.config.peak.js
@@ -187,6 +187,20 @@ module.exports = {
         '.break-decent': {
           wordBreak: 'break-word',
         },
+        // Fill icons that have a fill defined within their paths. For example coming from an asset container.
+        '.fill-current-cascade *': {
+          fill: 'currentColor',
+        },
+        // Easily switch direction on a grid.
+        '.ltr': {
+          direction: 'ltr',
+        },
+        '.rtl': {
+          direction: 'rtl',
+          '> *': {
+            direction: 'ltr',
+          },
+        },
       }
       addUtilities(newUtilities)
     }),


### PR DESCRIPTION
Changes proposed in this pull request:

- `fill-current-cascade` class for svg-icons that have a fill defined in them. For example when they come from an asset container. They would look empty when you don't define an inside fill. <img width="1152" alt="Screenshot 2021-11-10 at 13 18 20" src="https://user-images.githubusercontent.com/69107412/141111796-46ea4de1-a914-44ca-836c-84a68c61ea9a.png">
- `ltr` and `rtl` utilities you can use on a css grid container. For example you can do this in Antlers: 
`{{ images_position === 'right' ?= 'md:rtl' }}`. This will flip direction in your grid from `md` and up. 