### PR TITLE
Show localized versions in sitemap.xml

### DIFF
--- a/dev/resources/views/sitemap/sitemap.antlers.xml
+++ b/dev/resources/views/sitemap/sitemap.antlers.xml
@@ -3,7 +3,7 @@
 	@desc The sitemap template that renders a SEO friendy sitemap.xml.
 #}}
 {{ xml_header }}
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"{{ if {locales:count} > 1 }} xmlns:xhtml="http://www.w3.org/1999/xhtml"{{ /if }}>
     {{ seo:sitemap_collections }}
         {{ collection from="{handle}" seo_noindex:isnt="true" as="results" }}
             {{ results }}
@@ -12,6 +12,11 @@
                     <lastmod>{{ updated_at format="Y-m-d"}}</lastmod>
                     <changefreq>{{ sitemap_change_frequency ? sitemap_change_frequency : 'weekly' }}</changefreq>
                     <priority>{{ sitemap_priority ? sitemap_priority : '0.5' }}</priority>
+                    {{ if {locales:count} > 1 }}
+                        {{ locales }}
+                            <xhtml:link rel="alternate" hreflang="{{ locale:full }}" href="{{ permalink }}"/>
+                        {{ /locales }}
+                    {{ /if }}
                 </url>
             {{ /results }}
         {{ /collection }}


### PR DESCRIPTION
As described here: https://developers.google.com/search/docs/advanced/crawling/localized-versions?hl=en#sitemap

- Specify the xhtml namespace as follows: xmlns:xhtml="http://www.w3.org/1999/xhtml"
- Each <url> element must have a child element <xhtml:link rel="alternate" hreflang="supported_language-code"> that lists every alternate version of the page, *including itself*. The order of these child <xhtml:link> elements doesn't matter, though you might want to keep them in the same order to make them easier for you to check for mistakes.

*Always target the `/dev/` folder when proposing changes. *

Fixes # .

Changes proposed in this pull request:
-
-
-
