### PR TITLE
Improve table styling

### DIFF
--- a/dev/content/collections/pages/long-form-content.md
+++ b/dev/content/collections/pages/long-form-content.md
@@ -147,8 +147,8 @@ page_builder:
                 cells:
                   - eleifend
                   - mauris
-                  - tincidunt
-                  - Etiam
+                  - Torquent metus dis finibus odio fringilla facilisis euismod litora mauris eget sodales quis risus convallis penatibus condimentum volutpat integer laoreet
+                  - EtiamEx cras porttitor etiam bibendum ad facilisi est quam dolor sollicitudin commodo rutrum fames platea egestas sit erat blandit vehicula
             caption: 'Add tables with a caption.'
       -
         type: paragraph

--- a/dev/resources/views/components/_table.antlers.html
+++ b/dev/resources/views/components/_table.antlers.html
@@ -6,13 +6,13 @@
 
 <!-- /components/_table.antlers.html -->
 <div class="size-{{ size }} my-4 overflow-auto">
-    <table class="w-full bg-light border-collapse">
+    <table class="w-full bg-light border-collapse min-w-[580px] sm:min-w-none">
         {{ table }}
             {{ if first && first_row_headers }}
                 <thead>
                     <tr>
                         {{ cells }}
-                            <th class="px-3 xl:px-6 py-3 border-b border-neutral bg-neutral text-left text-xs font-bold text-white uppercase tracking-wider">{{ value }}</th>
+                            <th class="px-3 py-3 text-xs font-bold tracking-wider text-left text-white uppercase border-b xl:px-6 border-neutral bg-neutral">{{ value }}</th>
                         {{ /cells }}
                     </tr>
                 </thead>
@@ -27,9 +27,9 @@
                 <tr>
                     {{ cells }}
                         {{ if first && first_column_headers }}
-                            <th class="px-3 xl:px-6 py-3 border-b border-neutral bg-neutral text-left text-xs font-bold text-white uppercase tracking-wider">{{ value }}</th>
+                            <th class="px-3 py-3 text-xs font-bold tracking-wider text-left text-white uppercase border-b xl:px-6 border-neutral bg-neutral">{{ value }}</th>
                         {{ else }}
-                            <td class="px-3 xl:px-6 py-3 whitespace-nowrap border-b border-neutral text-sm leading-3 text-neutral">{{ value }}</td>
+                            <td class="px-3 py-3 text-sm border-b xl:px-6 border-neutral text-neutral">{{ value }}</td>
                         {{ /if }}
                     {{ /cells }}
                 </tr>


### PR DESCRIPTION
Remove whitespace-nowrap to avoid annoyingly long, horizontally scrolling lines. Add min width to trigger overflow scrolling on narrow viewports. Remove super tiny line height, add longer text to demo table. 

Demo: https://cln.sh/zYf69p

*Always target the `/dev/` folder when proposing changes to the kit (not the docs). *

Fixes # .

Changes proposed in this pull request:
-
