### PR TITLE
Add missing alt text widget

### DIFF
--- a/dev/app/Widgets/ImagesMissingAlt.php
+++ b/dev/app/Widgets/ImagesMissingAlt.php
@@ -24,7 +24,7 @@ class ImagesMissingAlt extends Widget
             });
 
         return view('widgets.images-missing-alt', [
-            'assets' => $assets,
+            'assets' => $assets->slice(0, 5),
             'amount' => count($assets),
         ]);
     }

--- a/dev/app/Widgets/ImagesMissingAlt.php
+++ b/dev/app/Widgets/ImagesMissingAlt.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Widgets;
+
+use Statamic\Widgets\Widget;
+
+class ImagesMissingAlt extends Widget
+{
+    /**
+     * The HTML that should be shown in the widget.
+     *
+     * @return string|\Illuminate\View\View
+     */
+    public function html()
+    {
+        $assets = \Statamic\Facades\Asset::query()
+            ->where('container', 'assets')
+            ->get()
+            ->toAugmentedArray();
+
+            // Filter assets without alt text.
+            $assets = collect($assets)->filter(function ($item) {
+                return ! isset($item['alt']);
+            });
+
+        return view('widgets.images-missing-alt', [
+            'assets' => $assets,
+            'amount' => count($assets),
+        ]);
+    }
+}

--- a/dev/config/statamic/cp.php
+++ b/dev/config/statamic/cp.php
@@ -38,7 +38,10 @@ return [
     */
 
     'widgets' => [
-        // 'getting_started',
+        [
+            'type' => 'images_missing_alt',
+            'width' => 50
+        ],
         [
             'type' => 'collection',
             'collection' => 'pages',
@@ -91,7 +94,7 @@ return [
     */
 
     'support_url' => env('STATAMIC_SUPPORT_URL', 'https://statamic.com/support'),
-    
+
      /*
     |--------------------------------------------------------------------------
     | Login Theme

--- a/dev/public/assets/.meta/a-peak.jpg.yaml
+++ b/dev/public/assets/.meta/a-peak.jpg.yaml
@@ -1,6 +1,8 @@
-data: {  }
-size: 1071973
-last_modified: 1627566540
-width: 3696
-height: 2448
+data:
+  alt: 'A Peak'
+size: 225058
+last_modified: 1643789386
+width: 1680
+height: 1113
 mime_type: image/jpeg
+duration: null

--- a/dev/resources/lang/en/strings.php
+++ b/dev/resources/lang/en/strings.php
@@ -64,4 +64,10 @@ return [
     // Social images
     'social_images'                     => 'Generated one social image.|Generated :count social images.',
     'social_images_queue'               => 'Generating one social image in the background.|Generating :count social images in the background.',
+
+    // Widgets
+    'widget_assets_title'               => 'Assets without Alt Text',
+    'widget_assets_edit'                => 'Edit this Asset',
+    'widget_assets_explanation'         => 'It\'s important to add alt text describing your images. This helps users who depend on assistive technology. You have :amount image that need attention.|It\'s important to add alt text describing your images. This helps users who depend on assistive technology. You have :amount images that need attention.',
+    'widget_assets_done'                => 'All assets have an alt text.',
 ];

--- a/dev/resources/lang/nl/strings.php
+++ b/dev/resources/lang/nl/strings.php
@@ -64,4 +64,10 @@ return [
     // Social images
     'social_images'                     => 'Generated one social image.|Generated :count social images.',
     'social_images_queue'               => 'Generating one social image in the background.|Generating :count social images in the background.',
+
+    // Widgets
+    'widget_assets_title'               => 'Assets zonder alt tekst',
+    'widget_assets_edit'                => 'Wijzig deze asset',
+    'widget_assets_explanation'         => 'Het is belangrijk om alt-teksten toe te voegen die je afbeeldingen omschrijven. Dit helpt gebruikers die afhankelijk zijn van ondersteunende technologie. Je hebt :amount afbeeldingen die je aandacht nodig hebben.|Het is belangrijk om alt-teksten toe te voegen die je afbeeldingen omschrijven. Dit helpt gebruikers die afhankelijk zijn van ondersteunende technologie. Je hebt :amount afbeelding die je aandacht nodig heeft.',
+    'widget_assets_done'                => 'All afbeeldingen hebben een alt-tekst.',
 ];

--- a/dev/resources/views/widgets/images-missing-alt.blade.php
+++ b/dev/resources/views/widgets/images-missing-alt.blade.php
@@ -1,0 +1,39 @@
+<div class="card p-0 overflow-hidden h-full">
+    <div class="flex justify-between items-center pt-2 px-2">
+        <h2>
+            <div class="flex items-center">
+                <div class="h-6 w-6 mr-1 text-grey-80">
+                    @cp_svg('assets')
+                </div>
+                <span>{{ __('strings.widget_assets_title') }}</span>
+            </div>
+        </h2>
+    </div>
+    <div class="content p-2">
+        <p>{{ trans_choice('strings.widget_assets_explanation', $amount, ['amount' => $amount]) }}</p>
+    </div>
+
+    @if ($assets)
+        <table tabindex="0" class="data-table">
+            <tbody tabindex="0">
+    @endif
+    @forelse ($assets->slice(0, 5) as $asset)
+        <tr class="sortable-row outline-none" tabindex="0">
+            <td>
+                <div class="flex items-center">
+                    <div class="little-dot mr-1 bg-red"></div>
+                    <a href="{{ $asset['edit_url'] }}" aria-label="{{ __('strings.widget_assets_edit') }}">{{ $asset['basename'] }}</a>
+                </div>
+            </td>
+            <td class="actions-column"></td>
+        </tr>
+    @empty
+        <div class="content p-2">
+            <p>{{ __('strings.widget_assets_done') }}</p>
+        </div>
+    @endforelse
+    @if ($assets)
+            </tbody>
+        </table>
+    @endif
+</div>

--- a/dev/resources/views/widgets/images-missing-alt.blade.php
+++ b/dev/resources/views/widgets/images-missing-alt.blade.php
@@ -17,7 +17,7 @@
         <table tabindex="0" class="data-table">
             <tbody tabindex="0">
     @endif
-    @forelse ($assets->slice(0, 5) as $asset)
+    @forelse ($assets as $asset)
         <tr class="sortable-row outline-none" tabindex="0">
             <td>
                 <div class="flex items-center">


### PR DESCRIPTION
This PR adds a widget that lists (max 5) images without an alt text to the dashboard.