### PR TITLE
Make pull quote markup more semantic

### DIFF
--- a/dev/resources/views/components/_pull_quote.antlers.html
+++ b/dev/resources/views/components/_pull_quote.antlers.html
@@ -5,7 +5,7 @@
 #}}
 
 <!-- /components/_pull_quote.antlers.html -->
-<div
+<figure
     class="
         not-prose
         {{ switch(
@@ -16,13 +16,13 @@
         )}}
     "
 >
-    <div class="p-0 m-0 text-primary italic text-3xl leading-snug">
+    <blockquote class="p-0 m-0 text-3xl italic leading-snug text-primary">
         {{ quote | nl2br }}
-    </div>
+    </blockquote>
     {{ if author }}
-        <span class="block mt-4 font-bold text-neutral">
+        <figcaption class="block mt-4 font-bold text-neutral">
             {{ author }}
-        </span>
+        </figcaption>
     {{ /if }}
-</div>
+</figure>
 <!-- End: /components/_pull_quote.antlers.html -->


### PR DESCRIPTION
Changes proposed in this pull request: 

- Change the pull quote's markup to a figure/blockquote/figcaption for better semantics ([further info on CSS Tricks](https://css-tricks.com/quoting-in-html-quotations-citations-and-blockquotes/#aa-hey-what-about-the-figure-element))
