### PR TITLE
Update browserSync to open with APP_URL from .env

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -16,6 +16,8 @@ mix.options({
 
 mix.browserSync({
     proxy: process.env.APP_URL,
+    host: process.env.APP_URL,
+    open: 'external',
     files: [
         'resources/views/**/*.html',
         'public/**/*.(css|js)',


### PR DESCRIPTION
As described in title – without this change it would open the browser with "localhost:3000" if the TLD of valet is not ".test"

*Always target the `/dev/` folder when proposing changes to the kit (not the docs). *

Fixes # .

Changes proposed in this pull request:
-
