### PR TITLE
Needs to be removed if browserSync host is defined

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME='Statamic Peak'
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=localhost
 
 DEBUGBAR_ENABLED=true
 


### PR DESCRIPTION
*Always target the `/dev/` folder when proposing changes to the kit (not the docs). *

Fixes # .

Changes proposed in this pull request:
-
