### PR TITLE
Update _seo.antlers.html

### DIFF
--- a/dev/resources/views/snippets/_seo.antlers.html
+++ b/dev/resources/views/snippets/_seo.antlers.html
@@ -6,18 +6,22 @@
 <!-- /snippets/_seo.antlers.html -->
 {{# Page title #}}
 <title>
-    {{ yield:seo_title }}
-    {{ seo_title ? seo_title : title }}
-    {{ seo:title_separator ? seo:title_separator : " &#124; " }}
-    {{ seo:change_page_title | where('collection', {collection}) }}
-        {{ if what_to_add == 'collection_title' }}
-            {{ collection:title }}
-        {{ elseif what_to_add == 'custom_text' }}
-            {{ custom_text }}
-        {{ /if }}
+     {{ if seo_title || yield:seo_title }}
+        {{ yield:seo_title }}
+        {{ seo_title }}
+    {{ else }}
+        {{ title }}
         {{ seo:title_separator ? seo:title_separator : " &#124; " }}
-    {{ /seo:change_page_title }}
-    {{ seo:site_name ? seo:site_name : config:app:name }}
+        {{ seo:change_page_title | where('collection', {collection}) }}
+            {{ if what_to_add == 'collection_title' }}
+                {{ collection:title }}
+            {{ elseif what_to_add == 'custom_text' }}
+                {{ custom_text }}
+            {{ /if }}
+            {{ seo:title_separator ? seo:title_separator : " &#124; " }}
+        {{ /seo:change_page_title }}
+        {{ seo:site_name ? seo:site_name : config:app:name }}
+    {{ /if }}
 </title>
 
 {{# Page description #}}


### PR DESCRIPTION
When you override the seo_title you want full control of the the title and not add the {{ seo:site_name }} or {{ config:app:name  }} to it.
For exampe if you change the seo_title to ` Peak, the greatest theme` and the site title is set to `Peak` it now output `Peak, the greatest theme | Peak`, but i want full control over the title when i change it manually. This PR fixes this so it does not add the {{ seo:site_name }} or {{ config:app:name  }}.

*Always target the `/dev/` folder when proposing changes to the kit (not the docs). *

Fixes # .

Changes proposed in this pull request:
-
