### PR TITLE
Update AppServiceProvider.php

### DIFF
--- a/dev/app/Providers/AppServiceProvider.php
+++ b/dev/app/Providers/AppServiceProvider.php
@@ -35,6 +35,9 @@ class AppServiceProvider extends ServiceProvider
         View::composer(['layout', 'errors/404'], function ($view) {
             if ($view['response_code'] == '404') {
                 $entry = GlobalSet::find('configuration')->inCurrentSite()->error_404_entry;
+                if(!$entry) {
+                    $entry = GlobalSet::find('configuration')->inDefaultSite()->error_404_entry;
+                }
                 $view->with($entry->toAugmentedArray());
             }
         });


### PR DESCRIPTION
Scenario: You have a multisite, link in the configuration global to the 404 page but do not publish the 404 page in all languages. This throws an error.

Changing this checks if the entry exists, else it returns the 404 of the default site

*Always target the `/dev/` folder when proposing changes to the kit (not the docs). *

Fixes # .

Changes proposed in this pull request:
-
