### PR TITLE
Update _toolbar.antlers.html

### DIFF
--- a/dev/resources/views/components/_toolbar.antlers.html
+++ b/dev/resources/views/components/_toolbar.antlers.html
@@ -6,7 +6,7 @@
 <!-- /components/_toolbar.antlers.html -->
 {{ if environment == 'local' }}
     <aside
-        class="fixed z-50 top-1 right-1 flex text-xs divide-x divide-white shadow-sm divide-solid motion-safe:transition-opacity hover:opacity-100"
+        class="fixed z-50 bottom-1 right-1 flex text-xs divide-x divide-white shadow-sm divide-solid motion-safe:transition-opacity hover:opacity-100"
         x-data="{ toolbarVisible: $persist(true).as('toolbarVisible') }"
         x-ref="toolbar"
         :class="{ 'opacity-100': toolbarVisible, 'opacity-0': !toolbarVisible }"


### PR DESCRIPTION
Align to the bottom.
Seems better because the toolbar always overlays the main navigation

*Always target the `/dev/` folder when proposing changes to the kit (not the docs). *

Fixes # .

Changes proposed in this pull request:
-
