### PR TITLE
Update _language_picker.antlers.html

### DIFF
--- a/dev/resources/views/navigation/_language_picker.antlers.html
+++ b/dev/resources/views/navigation/_language_picker.antlers.html
@@ -5,6 +5,12 @@
 #}}
 
 <!-- /navigation/_language_picker.antlers.html -->
+{{ totalOtherLanguages = 0 }}
+{{ locales all="false" self="false"  }}
+    {{ totalOtherLanguages += 1 }}
+{{ /locales }}
+
+{{ if totalOtherLanguages >= 1 }}
 <li
     x-data="{ languagePickerOpen: false }"
     @keyup.escape.stop.prevent="languagePickerOpen = false"
@@ -37,7 +43,7 @@
         @click.outside="languagePickerOpen = false"
         x-transition
     >
-        {{ locales all="true" self="false"  }}
+        {{ locales self="false"  }}
             <li>
                 <a
                     href="{{ permalink }}"
@@ -50,4 +56,5 @@
         {{ /locales }}
     </ul>
 </li>
+{{ /if }}
 <!-- End: /navigation/_language_picker.antlers.html -->


### PR DESCRIPTION
Issue: when using the language picker, it shows all the languages. You can switch to a non existing page.
 By removing `all="true"`  in the locales tag `{{ locales self="false"  }}` this is fixed.

Then there is a second issue.
When the page is not published in other languages it still shows the dropdown, but empty.

By setting a variable (thanks to the runtime parser), we can count all the languages. If there are more then 1 we can show the dropdown, else the language navigation is not shown.

Code

```
{{ totalOtherLanguages = 0 }}
{{ locales all="false" self="false"  }}
    {{ totalOtherLanguages += 1 }}
{{ /locales }}

```

_ps; this is maybe a bit dirty to do, but there seems no way to have a count of the active locales for a page._

Now we can do an `{{ if totalOtherLanguages >= 1 }} dropdown_code {{ /if }}`