### PR TITLE
Update full_width_image.antlers.html.stub

### DIFF
--- a/dev/app/Console/Commands/stubs/blocks/full_width_image.antlers.html.stub
+++ b/dev/app/Console/Commands/stubs/blocks/full_width_image.antlers.html.stub
@@ -16,7 +16,7 @@
     <div class="relative fluid-container grid md:grid-cols-12 gap-8">
         <article class="md:col-span-8 md:col-start-3">
             {{ title ?= { partial:typography/h2 :content="block:title" color="text-white" class="mb-4 text-center" } }}
-            {{ text ?= { partial:typography/p content="{ block:text | nl2br }" color="text-white" class="text-center" } }}
+            {{ text ?= { partial:typography/p :content="block:text" color="text-white" class="text-center" } }}
             {{ partial:components/buttons inverted="true" class="justify-center" }}
         </article>
     </div>


### PR DESCRIPTION
Tiny fix:
partial:typography/p already has the nl2br modifier, so it can be removed here, otherwise `<br>`'s are doubled

Always target the `/dev/` folder when proposing changes to the kit (not the docs). Make sure you [discussed your idea](https://github.com/studio1902/statamic-peak/discussions) before doing a PR.

Fixes # .

Changes proposed in this pull request:
-
