### PR TITLE
Small fix

### DIFF
--- a/dev/app/Console/Commands/stubs/blocks/columns.antlers.html.stub
+++ b/dev/app/Console/Commands/stubs/blocks/columns.antlers.html.stub
@@ -12,7 +12,7 @@
                 {{ switch(
                     (total_results == 1) => 'md:col-span-6 md:col-start-4',
                     (total_results == 2) => 'md:col-span-6',
-                    (total_results == 3) => 'md:col-span-4',
+                    (total_results >= 3) => 'md:col-span-4',
                 )}}
             "
         >
@@ -21,7 +21,7 @@
                     { switch(
                         (total_results == 1) => '90vw',
                         (total_results == 2) => '(min-width: 768px) 50vw, 90vw',
-                        (total_results == 3) => '(min-width: 768px) 33vw, 90vw',
+                        (total_results >= 3) => '(min-width: 768px) 33vw, 90vw',
                     )}
                 "
                 aspect_ratio="{ total_results > 1 ?= 'large:4/3' }"


### PR DESCRIPTION
When 4 or more columns are added, they don't get a css class. Could also be fixed by adding a limit to the amount of columns that can be added.

![Screenshot 2022-10-19 at 15 26 05](https://user-images.githubusercontent.com/102222824/196704616-96eb6948-a434-4a1d-8125-adde0961a580.png)

Always target the `/dev/` folder when proposing changes to the kit (not the docs). Make sure you [discussed your idea](https://github.com/studio1902/statamic-peak/discussions) before doing a PR.

Fixes # .

Changes proposed in this pull request:
-
