### PR TITLE
Change indentation to 2 spaces

### DIFF
--- a/dev/app/Console/Commands/stubs/collection.yaml.stub
+++ b/dev/app/Console/Commands/stubs/collection.yaml.stub
@@ -6,6 +6,6 @@ revisions: {{ revisions }}
 date: {{ dated }}
 sort_dir: {{ sort_dir }}
 date_behavior:
-    past: {{ date_past }}
-    future: {{ date_future }}
+  past: {{ date_past }}
+  future: {{ date_future }}
 mount: {{ mount }}


### PR DESCRIPTION
`collection.yaml.stub` is the only YAML stub that uses 4 spaces instead of 2 for indentation. Adjusted for consistency with others.
