### PR TITLE
Add plausible analytics options to SEO globals

### DIFF
--- a/resources/blueprints/globals/seo.yaml
+++ b/resources/blueprints/globals/seo.yaml
@@ -462,6 +462,55 @@ sections:
           instructions: "Configure privacy friendly trackers that don't require a cookie notification."
           display: 'Privacy Friendly Trackers'
       -
+        handle: use_plausible
+        field:
+          type: toggle
+          instructions: 'Add plausible tracking code to your head.'
+          listable: false
+          display: plausible
+          width: 50
+      -
+        handle: plausible_use_custom_script
+        field:
+          type: toggle
+          instructions: 'For when you are you using a self hosted install or proxying the script.'
+          listable: false
+          width: 50
+          display: 'Custom script'
+          instructions_position: above
+          default: false
+          if:
+            use_plausible: 'equals true'
+      -
+        handle: plausible
+        field:
+          width: 50
+          display: 'Site Domain'
+          instructions: 'Specify the domain of your site you wish track visits on.'
+          input_type: text
+          type: text
+          listable: hidden
+          validate:
+            - 'required_if:use_plausible,true'
+          if:
+            use_plausible: 'equals true'
+      -
+        handle: plausible_custom_script_url
+        field:
+          width: 50
+          display: 'Custom script'
+          instructions: 'Add the full script URL.'
+          input_type: url
+          type: text
+          listable: hidden
+          validate:
+            - 'required_if:plausible_use_custom_domain,true'
+          if:
+            use_plausible: 'equals true'
+            plausible_use_custom_script: 'equals true'
+          instructions_position: above
+          antlers: false
+      -
         handle: use_fathom
         field:
           type: toggle

--- a/resources/views/snippets/_seo.antlers.html
+++ b/resources/views/snippets/_seo.antlers.html
@@ -224,6 +224,12 @@
         <meta name="google-site-verification" content="{{ seo:google_site_verification }}" />
     {{ /if }}
 
+    {{ if seo:use_plausible && seo:plausible_use_custom_script }}
+        <script defer data-domain="{{ seo:plausible }}" src="{{ seo:plausible_custom_script_url }}"></script>
+    {{ elseif seo:use_plausible }}
+        <script defer data-domain="{{ seo:plausible }}" src="https://plausible.io/js/script.js"></script>
+    {{ /if }}
+
     {{ if seo:use_fathom && seo:fathom_use_custom_domain }}
         <script src="{{ seo:fathom_custom_script_url }}" site="{{ seo:fathom }}" defer></script>
     {{ elseif seo:use_fathom }}


### PR DESCRIPTION
Added option to use plausible analytics (plausible.io) in the SEO globals and added relevant script tag to SEO partial when enabled.