### PR TITLE
Add xs mobile breakpoint to Live Preview device selector

### DIFF
--- a/dev/config/statamic/live_preview.php
+++ b/dev/config/statamic/live_preview.php
@@ -13,6 +13,7 @@ return [
     */
 
     'devices' => [
+        'xs' => ['width' => 375, 'height' => 667],
         'sm' => ['width' => 640, 'height' => 786],
         'md' => ['width' => 768, 'height' => 1024],
         'lg' => ['width' => 1024, 'height' => 800],

--- a/dev/resources/views/snippets/_seo.antlers.html
+++ b/dev/resources/views/snippets/_seo.antlers.html
@@ -26,7 +26,7 @@
 
 {{# Page description #}}
 {{ if seo_description }}
-   <meta name="description" content="{{ seo_description }}">
+   <meta name="description" content="{{ seo_description | strip_tags | entities | trim }}">
 {{ elseif seo:collection_defaults }}
    <meta name="description" content="{{ partial:snippets/fallback_description }}">
 {{ /if }}
@@ -110,7 +110,7 @@
                    {
                        "@type": "ListItem",
                        "position": {{ count }},
-                       "name": "{{ title }}",
+                       "name": "{{ title | strip_tags | entities | trim }}",
                        "item": "{{ permalink }}"
                    } {{ unless last}},{{ /unless}}
                {{ /nav:breadcrumbs }}
@@ -124,14 +124,14 @@
 <meta property="og:type" content="website">
 <meta property="og:locale" content="{{ site:locale }}">
 {{ if og_title }}
-   <meta property="og:title" content="{{ og_title }}">
+   <meta property="og:title" content="{{ og_title | strip_tags | entities | trim }}">
 {{ else }}
-   <meta property="og:title" content="{{ seo_title ? seo_title : title }}">
+   <meta property="og:title" content="{{ seo_title ? (seo_title | strip_tags | entities | trim) : (title | strip_tags | entities | trim) }}">
 {{ /if }}
 {{ if og_description }}
-   <meta property="og:description" content="{{ og_description }}">
+   <meta property="og:description" content="{{ og_description | strip_tags | entities | trim }}">
 {{ elseif seo_description }}
-   <meta property="og:description" content="{{ seo_description }}">
+   <meta property="og:description" content="{{ seo_description | strip_tags | entities | trim }}">
 {{ elseif seo:collection_defaults }}
    <meta property="og:description" content="{{ partial:snippets/fallback_description }}">
 {{ /if }}
@@ -146,14 +146,14 @@
    <meta name="twitter:card" content="summary_large_image">
    <meta name="twitter:site" content="{{ seo:twitter_handle }}">
    {{ if og_title }}
-       <meta name="twitter:title" content="{{ og_title }}">
+       <meta name="twitter:title" content="{{ og_title | strip_tags | entities | trim }}">
    {{ else }}
-       <meta name="twitter:title" content="{{ seo_title ? seo_title : title }}">
+       <meta name="twitter:title" content="{{ seo_title ? (seo_title | strip_tags | entities | trim) : (title  | strip_tags | entities | trim) }}">
    {{ /if }}
    {{ if og_description }}
-       <meta name="twitter:description" content="{{ og_description }}">
+       <meta name="twitter:description" content="{{ og_description | strip_tags | entities | trim }}">
    {{ elseif seo_description }}
-       <meta name="twitter:description" content="{{ seo_description }}">
+       <meta name="twitter:description" content="{{ seo_description | strip_tags | entities | trim }}">
    {{ elseif seo:collection_defaults }}
        <meta name="twitter:description" content="{{ partial:snippets/fallback_description }}">
    {{ /if }}

--- a/dev/resources/views/snippets/_seo.antlers.html
+++ b/dev/resources/views/snippets/_seo.antlers.html
@@ -26,7 +26,7 @@
 
 {{# Page description #}}
 {{ if seo_description }}
-   <meta name="description" content="{{ seo_description | strip_tags | entities | trim }}">
+   <meta name="description" content="{{ seo_description }}">
 {{ elseif seo:collection_defaults }}
    <meta name="description" content="{{ partial:snippets/fallback_description }}">
 {{ /if }}
@@ -110,7 +110,7 @@
                    {
                        "@type": "ListItem",
                        "position": {{ count }},
-                       "name": "{{ title | strip_tags | entities | trim }}",
+                       "name": "{{ title }}",
                        "item": "{{ permalink }}"
                    } {{ unless last}},{{ /unless}}
                {{ /nav:breadcrumbs }}
@@ -124,14 +124,14 @@
 <meta property="og:type" content="website">
 <meta property="og:locale" content="{{ site:locale }}">
 {{ if og_title }}
-   <meta property="og:title" content="{{ og_title | strip_tags | entities | trim }}">
+   <meta property="og:title" content="{{ og_title }}">
 {{ else }}
-   <meta property="og:title" content="{{ seo_title ? (seo_title | strip_tags | entities | trim) : (title | strip_tags | entities | trim) }}">
+   <meta property="og:title" content="{{ seo_title ? seo_title : title }}">
 {{ /if }}
 {{ if og_description }}
-   <meta property="og:description" content="{{ og_description | strip_tags | entities | trim }}">
+   <meta property="og:description" content="{{ og_description }}">
 {{ elseif seo_description }}
-   <meta property="og:description" content="{{ seo_description | strip_tags | entities | trim }}">
+   <meta property="og:description" content="{{ seo_description }}">
 {{ elseif seo:collection_defaults }}
    <meta property="og:description" content="{{ partial:snippets/fallback_description }}">
 {{ /if }}
@@ -146,14 +146,14 @@
    <meta name="twitter:card" content="summary_large_image">
    <meta name="twitter:site" content="{{ seo:twitter_handle }}">
    {{ if og_title }}
-       <meta name="twitter:title" content="{{ og_title | strip_tags | entities | trim }}">
+       <meta name="twitter:title" content="{{ og_title }}">
    {{ else }}
-       <meta name="twitter:title" content="{{ seo_title ? (seo_title | strip_tags | entities | trim) : (title  | strip_tags | entities | trim) }}">
+       <meta name="twitter:title" content="{{ seo_title ? seo_title : title }}">
    {{ /if }}
    {{ if og_description }}
-       <meta name="twitter:description" content="{{ og_description | strip_tags | entities | trim }}">
+       <meta name="twitter:description" content="{{ og_description }}">
    {{ elseif seo_description }}
-       <meta name="twitter:description" content="{{ seo_description | strip_tags | entities | trim }}">
+       <meta name="twitter:description" content="{{ seo_description }}">
    {{ elseif seo:collection_defaults }}
        <meta name="twitter:description" content="{{ partial:snippets/fallback_description }}">
    {{ /if }}


### PR DESCRIPTION
I found a mobile breakpoint for smaller phones was missing in the device selector. The added change reflects the size of an iPhone SE.