### PR TITLE
Only transition transfrom for skip link

### DIFF
--- a/dev/resources/views/navigation/_skip_to_content.antlers.html
+++ b/dev/resources/views/navigation/_skip_to_content.antlers.html
@@ -4,7 +4,7 @@
 #}}
 
 <!-- /navigation/_skip_to_content.antlers.html -->
-<a class="fixed z-50 hidden md:block top-4 left-8 py-2 px-4 bg-primary text-white text-sm font-bold -translate-y-24 opacity-0 focus-visible:translate-y-0 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 ring-primary ring-offset-2 motion-safe:transition-all" href="#content">
+<a class="fixed z-50 hidden px-4 py-2 text-sm font-bold text-white -translate-y-24 opacity-0 md:block top-4 left-8 bg-primary focus-visible:translate-y-0 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 ring-primary ring-offset-2 motion-safe:transition-transform" href="#content">
     {{ trans:strings.skip_to_content }}
 </a>
 <!-- End: /navigation/_skip_to_content.antlers.html -->

--- a/dev/resources/views/navigation/_skip_to_content.antlers.html
+++ b/dev/resources/views/navigation/_skip_to_content.antlers.html
@@ -4,7 +4,7 @@
 #}}
 
 <!-- /navigation/_skip_to_content.antlers.html -->
-<a class="fixed z-50 hidden px-4 py-2 text-sm font-bold text-white -translate-y-24 opacity-0 md:block top-4 left-8 bg-primary focus-visible:translate-y-0 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 ring-primary ring-offset-2 motion-safe:transition-transform" href="#content">
+<a class="fixed z-50 px-4 py-2 text-sm font-bold text-white -translate-y-24 opacity-0 top-4 left-8 bg-primary focus-visible:translate-y-0 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 ring-primary ring-offset-2 motion-safe:transition-transform" href="#content">
     {{ trans:strings.skip_to_content }}
 </a>
 <!-- End: /navigation/_skip_to_content.antlers.html -->


### PR DESCRIPTION
Changes proposed in this pull request:
The skip-to-content links flash up in an undesired way in Chrome (Version 107.0.5304.110 arm64) when navigating from page to page.

Somehow, a transition out-seems to be triggered even though there is now focus on the skip link. Changing to only transition the transform keeps the slide-in-on-focus effect in place but gets rid of the unwanted flashes

https://user-images.githubusercontent.com/435825/201144863-9293da31-eae8-40f2-863e-e3966c3b2074.mp4

