### PR TITLE
Use arrow function to preserve context for `this`

### DIFF
--- a/resources/js/site.js
+++ b/resources/js/site.js
@@ -11,7 +11,7 @@ window.getToken = async () => {
         .then((data) => {
             return data.csrf_token
         })
-        .catch(function (error) {
+        .catch((error) => {
             this.error = 'Something went wrong. Please try again later.'
         })
 }


### PR DESCRIPTION
Changes proposed in this pull request:
Use arrow function in `getToken()` to preserve context for `this`