### PR TITLE
Fixed the order of quote's string modifiers

### DIFF
--- a/resources/views/components/_pull_quote.antlers.html
+++ b/resources/views/components/_pull_quote.antlers.html
@@ -17,7 +17,7 @@
     "
 >
     <blockquote class="p-0 m-0 text-3xl font-bold leading-snug text-neutral">
-        <span class="text-primary">&OpenCurlyDoubleQuote;</span>{{ quote | nl2br | widont}}<span class="text-primary">&CloseCurlyDoubleQuote;</span>
+        <span class="text-primary">&OpenCurlyDoubleQuote;</span>{{ quote | widont | nl2br }}<span class="text-primary">&CloseCurlyDoubleQuote;</span>
     </blockquote>
     {{ if author }}
         <figcaption class="block mt-4 font-bold text-neutral">


### PR DESCRIPTION
Fixes #338.

Changes proposed in this pull request:
- Changing the order of quote's string modifiers to correctly render new lines by the `Block quote` set