### PR TITLE
Fix typos in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Add support for Statamic Peak SEO v5.0. f905135e by @robdekort
 
 ### What's improved
-- Update dependecies. 55412650 by @robdekort
+- Update dependencies. 55412650 by @robdekort
 
 ## v13.3 (2023-08-01)
 
@@ -194,7 +194,7 @@
 ## v11.1 (2023-03-09)
 
 ### What's improved
-- Move the Statamic conditonal field form helpers to the Statamic Peak Tools addon. b6e8e080 by @robdekort
+- Move the Statamic conditional field form helpers to the Statamic Peak Tools addon. b6e8e080 by @robdekort
 
 ## v11.0 (2023-03-09)
 
@@ -705,7 +705,7 @@
 ## v5.16 (2022-09-27)
 
 ### What's improved
-- Reset class parameter on buttons to avoid collissions. 9a53c281 by @robdekort
+- Reset class parameter on buttons to avoid collisions. 9a53c281 by @robdekort
 - Wait for the network being idle when generating social images to make sure assets are loaded. e94725f2 by @robdekort
 
 ## v5.15.1 (2022-09-14)
@@ -787,7 +787,7 @@
 ## v5.4.1 (2022-08-07)
 
 ### What's fixed
-- Reset class paramater as well to circumvent an unintended breaking Statamic change (#237) *only* for new users. 23b1c7ef by @robdekort
+- Reset class parameter as well to circumvent an unintended breaking Statamic change (#237) *only* for new users. 23b1c7ef by @robdekort
 
 ## v5.4 (2022-08-06)
 
@@ -950,7 +950,7 @@
 ## v4.3 (2022-03-21)
 
 ### What's fixed
-- Fix max width collision with the article page builder block. afe26aa9 by @robdekort
+- Fix max width collision with the article page builder block. safe26aa9 by @robdekort
 
 ## v4.2 (2022-03-17)
 
@@ -1035,7 +1035,7 @@
 ## v3.48.0 (2022-01-17)
 
 ### What's new
-- Alias dark mode localStorage variable and dynamically update the `theme-color` meta tag when using dark mode and seperate normal/dark mode theme colors. f5a53e4b by @robdekort
+- Alias dark mode localStorage variable and dynamically update the `theme-color` meta tag when using dark mode and separate normal/dark mode theme colors. f5a53e4b by @robdekort
 
 ## v3.47.0 (2022-01-17)
 
@@ -1503,7 +1503,7 @@ Files new/changed:
 - Rename `bard` to `article` in `resources/views/search.antlers.html`.
 - Explain how redirects work better in `resources/blueprints/globals/redirects.yaml`.
 - Use a unique form ID per form in `resources/views/page_builder/_form.antlers.html`. Thanks [Daniel](https://github.com/klickreflex).
-- Seperate form fields from form logic in `resources/views/page_builder/_form.antlers.html` by adding `resources/views/snippets/_form_fields.antlers.html`. Thanks [Daniel](https://github.com/klickreflex).
+- Separate form fields from form logic in `resources/views/page_builder/_form.antlers.html` by adding `resources/views/snippets/_form_fields.antlers.html`. Thanks [Daniel](https://github.com/klickreflex).
 - Use placeholder data in `resources/views/vendor/statamic/forms/fields/text.antlers.html` and `resources/views/vendor/statamic/forms/fields/textarea.antlers.html`. Thanks [Sense and Image](https://github.com/SenseAndImage).
 - Exclude the sitemap from static caching in `config/statamic/static_caching.php`. Thanks [Sense and Image](https://github.com/SenseAndImage).
 
@@ -1539,7 +1539,7 @@ Files new/changed:
 ## 1.31.0 (2021-06-18)
 
 ### What's improved
-- Make cookie banner decline button actually readeable by default.
+- Make cookie banner decline button actually readable by default.
 - No more whitespace in the default textarea view in `resources/views/vendor/statamic/forms/fields/textarea.antlers.html`.
 Upgrade to AlpineJS v3:
 - Defer loading of the script tag in the document head in `resources/views/layout.antlers.html`.
@@ -1554,7 +1554,7 @@ Upgrade to AlpineJS v3:
 Upgrade to Tailwind 2.2:
 - Move `::selection` from the tailwind config to `resources/views/layout.antlers.html` as utility classes.
 - Added caret color utilities to the appropriate published form views.
-- Remove the now redudant `transform` utility (so is `filter` but we don't use it by default).
+- Remove the now redundant `transform` utility (so is `filter` but we don't use it by default).
 - Re-added an empty `safelist` array in `tailwind.config.js` since the JIT engine now supports protecting classes from being purged.
 
 ## 1.29.6 (2021-06-16)
@@ -1627,7 +1627,7 @@ Upgrade to Tailwind 2.2:
 
 ### What's new
 - The ability to auto generate social images based on a template you control. [Read the docs here](https://peak.1902.studio/features/social-images-generation.html).
-- Social images are now saved in a seperate asset container.
+- Social images are now saved in a separate asset container.
 
 ## 1.27.8 (2021-05-10)
 
@@ -1870,7 +1870,7 @@ Peak now has it's own docs thanks to Robert Guss: [the Peak docs](https://peak.1
 - Use Mailhog as the default SMTP config in `.env.example` since it's a local service and free, unlike Mailtrap, the Laravel default. Run `brew install mailhog`, `valet proxy mailhog http://127.0.0.1:8025` and catch your mails on `https://mailhog.test`.
 
 ### What's improved
-- Published the password reset blade views and removed rad mode to be in line with the login view. This method will likely improve siginificantly with the upcoming release of Statamic 3.1 containing white-labeling features.
+- Published the password reset blade views and removed rad mode to be in line with the login view. This method will likely improve significantly with the upcoming release of Statamic 3.1 containing white-labeling features.
 
 ## 1.20.3 (2021-02-09)
 
@@ -1887,7 +1887,7 @@ Peak now has it's own docs thanks to Robert Guss: [the Peak docs](https://peak.1
 
 ### What's new
 - The ability to override different favicons with custom assets.
-- The Tailwind breakpoint pill replaced by a toolbar in the top right corner. It also contains an edit button when you're logged in. The toolbar can be permantly fixed to your window by toggling the button. A great idea by [Kerns](https://github.com/kerns).
+- The Tailwind breakpoint pill replaced by a toolbar in the top right corner. It also contains an edit button when you're logged in. The toolbar can be permanently fixed to your window by toggling the button. A great idea by [Kerns](https://github.com/kerns).
 
 ### What's improved
 - Use fakerphp/faker instead of fzaninotto/faker. Thanks [Julius](https://github.com/Jubeki).
@@ -2016,12 +2016,12 @@ Peak now has it's own docs thanks to Robert Guss: [the Peak docs](https://peak.1
 ## 1.18.3 (2021-01-08)
 
 ### What's improved
-- Update `tailwind.config.js` proper key for `darkMode`, remove `future` and `expiremental` keys. Thanks [Vlad](https://github.com/vladdu).
+- Update `tailwind.config.js` proper key for `darkMode`, remove `future` and `experimental` keys. Thanks [Vlad](https://github.com/vladdu).
 
 ## 1.18.2 (2021-01-07)
 
 ### What's improved
-- Fix CSS selector and value so the negative margin bottom actually works on last childs with a class of `w-full` in the `outer-grid`. Thank you [Manuel](https://github.com/mnlmaier).
+- Fix CSS selector and value so the negative margin bottom actually works on last children with a class of `w-full` in the `outer-grid`. Thank you [Manuel](https://github.com/mnlmaier).
 
 ## 1.18.1 (2021-01-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -950,7 +950,7 @@
 ## v4.3 (2022-03-21)
 
 ### What's fixed
-- Fix max width collision with the article page builder block. safe26aa9 by @robdekort
+- Fix max width collision with the article page builder block. afe26aa9 by @robdekort
 
 ## v4.2 (2022-03-17)
 


### PR DESCRIPTION
Changes proposed in this pull request:

Found some misspellings. All "tpyo"-s were left alone.
Please consider adding `typos` to your CI.
