### PR TITLE
Add height to default asset preset

### DIFF
--- a/config/statamic/assets.php
+++ b/config/statamic/assets.php
@@ -97,7 +97,7 @@ return [
         */
 
         'presets' => [
-            'replacement' => ['w' => 4500, 'fit' => 'max'],
+            'replacement' => ['w' => 4500, 'h' => 4500, 'fit' => 'max'],
         ],
 
         /*


### PR DESCRIPTION
The default preset is working great with landscape images. But when you upload a **portrait** image, it does not take effect. Run into this on a current project and with this setting, it now works for portrait images, too.