### PR TITLE
Add German translation for select form fields

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -4,5 +4,6 @@
     "Fax": "Fax",
     "I agree that my submitted data is being collected and stored.": "Ich bin einverstanden, dass meine übermittelten Daten gespeichert werden.",
     "Message": "Nachricht",
-    "Name": "Name"
+    "Name": "Name",
+    "Please select...": "Bitte auswählen …"
 }


### PR DESCRIPTION
We've had this one yesterday [in the discord](https://discord.com/channels/793146959635939329/793146959635939332/1146104526991011910). The select form field placeholder text is not translated to German. Added it in this PR. Example in the image: 
<img width="805" alt="Screenshot 2023-08-30 at 11 38 46" src="https://github.com/studio1902/statamic-peak/assets/1247666/2e6091cb-b8f9-475d-b28b-d5e69f063f4b">
