### PR TITLE
Migrate PostInstall Laravel Prompts

### DIFF
--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -45,6 +45,8 @@ class StarterKitPostInstall
         $this->enableSaveCachedImages();
 
         $this->writeEnvAndReadme();
+
+        info("[✓] `.env` file overwritten.");
     }
 
     protected function initializeGitAndConfigureGitignore(): void

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -57,7 +57,7 @@ class StarterKitPostInstall
         $appName = text(
             label: 'What should be your app name?',
             placeholder: 'Statamic Peak',
-            default: 'Statamic Peak',
+            required: true,
         );
 
         $appName = preg_replace('/([\'|\"|#])/m', '', $appName);

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -46,86 +46,6 @@ class StarterKitPostInstall
         $this->writeEnvAndReadme();
     }
 
-    protected function loadPresetEnvAndReadme(): void
-    {
-        $this->env = app('files')->get(base_path('.env.example'));
-        $this->readme = app('files')->get(base_path('README.md'));
-    }
-
-    protected function setAppName(): void
-    {
-        $appName = text(
-            label: 'What should be your app name?',
-            placeholder: 'Statamic Peak',
-            required: true,
-        );
-
-        $appName = preg_replace('/([\'|\"|#])/m', '', $appName);
-
-        $this->replaceInEnv('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"");
-        $this->replaceInReadme('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"");
-    }
-
-    protected function replaceInEnv(string $search, string $replace): void
-    {
-        $this->env = str_replace($search, $replace, $this->env);
-    }
-
-    protected function replaceInReadme(string $search, string $replace): void
-    {
-        $this->readme = str_replace($search, $replace, $this->readme);
-    }
-
-    protected function setAppUrl(): void
-    {
-        $appUrl = env('APP_URL');
-
-        $this->replaceInEnv('APP_URL=', "APP_URL=\"{$appUrl}\"");
-    }
-
-    protected function setAppKey(): void
-    {
-        $appKey = env('APP_KEY');
-
-        $this->replaceInEnv('APP_KEY=', "APP_KEY=\"{$appKey}\"");
-        $this->replaceInReadme('APP_KEY=', "APP_KEY=\"{$appKey}\"");
-    }
-
-    protected function useDebugbar(): void
-    {
-        if (confirm(label: 'Do you want to use the debugbar?', default: false,)) {
-            return;
-        }
-
-        $this->replaceInEnv('DEBUGBAR_ENABLED=true', 'DEBUGBAR_ENABLED=false');
-    }
-
-    protected function useImagick(): void
-    {
-        if (!confirm(label: 'Do you want use Imagick as an image processor instead of GD?', default: true,)) {
-            return;
-        }
-
-        $this->replaceInEnv('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick');
-        $this->replaceInReadme('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick');
-    }
-
-    protected function enableSaveCachedImages(): void
-    {
-        if (!confirm(label: 'Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?', default: false,)) {
-            return;
-        }
-
-        $this->replaceInEnv('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true');
-        $this->replaceInReadme('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true');
-    }
-
-    protected function writeEnvAndReadme(): void
-    {
-        app('files')->put(base_path('.env'), $this->env);
-        app('files')->put(base_path('README.md'), $this->readme);
-    }
-
     protected function initializeGitAndConfigureGitignore(): void
     {
         if (!confirm(label: 'Do you want to init a git repo and configure gitignore?', default: true,)) {
@@ -137,54 +57,6 @@ class StarterKitPostInstall
         $this->excludeBuildFolderFromGit();
         $this->excludeUsersFolderFromGit();
         $this->excludeFormsFolderFromGit();
-    }
-
-    protected function initializeGitRepo(): void
-    {
-        $this->runCommand('git init', fn() => info('Repo initialised.'));
-    }
-
-    protected function runCommand(string $command, callable $callback): void
-    {
-        $process = new Process(explode(' ', $command));
-        try {
-            $process->mustRun();
-            $callback();
-        } catch (ProcessFailedException $exception) {
-            error($exception->getMessage());
-        }
-    }
-
-    protected function excludeBuildFolderFromGit(): void
-    {
-        if (!confirm(label: 'Do you want to exclude the `public/build` folder from git?', default: true,)) {
-            return;
-        }
-
-        $this->appendToGitignore('/public/build/');
-    }
-
-    protected function appendToGitignore(string $toIgnore): void
-    {
-        app('files')->append(base_path('.gitignore'), "\n{$toIgnore}");
-    }
-
-    protected function excludeUsersFolderFromGit(): void
-    {
-        if (!confirm(label: 'Do you want to exclude the `users` folder from git?', default: false,)) {
-            return;
-        }
-
-        $this->appendToGitignore('/users');
-    }
-
-    protected function excludeFormsFolderFromGit(): void
-    {
-        if (!confirm(label: 'Do you want to exclude the `storage/form` folder from git?', default: false,)) {
-            return;
-        }
-
-        $this->appendToGitignore('/storage/forms');
     }
 
     protected function installNodeDependencies(): void
@@ -204,16 +76,6 @@ class StarterKitPostInstall
 
         $this->installPuppeteer();
         $this->installBrowsershot();
-    }
-
-    protected function installPuppeteer(): void
-    {
-        $this->runCommand('npm i puppeteer', fn() => info('Puppeteer installed.'));
-    }
-
-    protected function installBrowsershot(): void
-    {
-        $this->runCommand('composer require spatie/browsershot', fn() => info('Browsershot installed.'));
     }
 
     protected function installTranslations(): void
@@ -280,5 +142,143 @@ class StarterKitPostInstall
         warning('Run `php please peak:clear-site` to get rid of default content.');
         warning('Run `php please peak:install-preset` to install premade sets onto your website.');
         warning('Run `php please peak:install-block` to install premade blocks onto your page builder.');
+    }
+
+    protected function loadPresetEnvAndReadme(): void
+    {
+        $this->env = app('files')->get(base_path('.env.example'));
+        $this->readme = app('files')->get(base_path('README.md'));
+    }
+
+    protected function setAppName(): void
+    {
+        $appName = text(
+            label: 'What should be your app name?',
+            placeholder: 'Statamic Peak',
+            required: true,
+        );
+
+        $appName = preg_replace('/([\'|\"|#])/m', '', $appName);
+
+        $this->replaceInEnv('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"");
+        $this->replaceInReadme('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"");
+    }
+
+    protected function setAppUrl(): void
+    {
+        $appUrl = env('APP_URL');
+
+        $this->replaceInEnv('APP_URL=', "APP_URL=\"{$appUrl}\"");
+    }
+
+    protected function setAppKey(): void
+    {
+        $appKey = env('APP_KEY');
+
+        $this->replaceInEnv('APP_KEY=', "APP_KEY=\"{$appKey}\"");
+        $this->replaceInReadme('APP_KEY=', "APP_KEY=\"{$appKey}\"");
+    }
+
+    protected function useDebugbar(): void
+    {
+        if (confirm(label: 'Do you want to use the debugbar?', default: false,)) {
+            return;
+        }
+
+        $this->replaceInEnv('DEBUGBAR_ENABLED=true', 'DEBUGBAR_ENABLED=false');
+    }
+
+    protected function useImagick(): void
+    {
+        if (!confirm(label: 'Do you want use Imagick as an image processor instead of GD?', default: true,)) {
+            return;
+        }
+
+        $this->replaceInEnv('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick');
+        $this->replaceInReadme('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick');
+    }
+
+    protected function enableSaveCachedImages(): void
+    {
+        if (!confirm(label: 'Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?', default: false,)) {
+            return;
+        }
+
+        $this->replaceInEnv('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true');
+        $this->replaceInReadme('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true');
+    }
+
+    protected function writeEnvAndReadme(): void
+    {
+        app('files')->put(base_path('.env'), $this->env);
+        app('files')->put(base_path('README.md'), $this->readme);
+    }
+
+    protected function initializeGitRepo(): void
+    {
+        $this->runCommand('git init', fn() => info('Repo initialised.'));
+    }
+
+    protected function excludeBuildFolderFromGit(): void
+    {
+        if (!confirm(label: 'Do you want to exclude the `public/build` folder from git?', default: true,)) {
+            return;
+        }
+
+        $this->appendToGitignore('/public/build/');
+    }
+
+    protected function excludeUsersFolderFromGit(): void
+    {
+        if (!confirm(label: 'Do you want to exclude the `users` folder from git?', default: false,)) {
+            return;
+        }
+
+        $this->appendToGitignore('/users');
+    }
+
+    protected function excludeFormsFolderFromGit(): void
+    {
+        if (!confirm(label: 'Do you want to exclude the `storage/form` folder from git?', default: false,)) {
+            return;
+        }
+
+        $this->appendToGitignore('/storage/forms');
+    }
+
+    protected function runCommand(string $command, callable $callback): void
+    {
+        $process = new Process(explode(' ', $command));
+        try {
+            $process->mustRun();
+            $callback();
+        } catch (ProcessFailedException $exception) {
+            error($exception->getMessage());
+        }
+    }
+
+    protected function installPuppeteer(): void
+    {
+        $this->runCommand('npm i puppeteer', fn() => info('Puppeteer installed.'));
+    }
+
+    protected function installBrowsershot(): void
+    {
+        $this->runCommand('composer require spatie/browsershot', fn() => info('Browsershot installed.'));
+    }
+
+    protected function replaceInEnv(string $search, string $replace): void
+    {
+        $this->env = str_replace($search, $replace, $this->env);
+    }
+
+    protected function replaceInReadme(string $search, string $replace): void
+    {
+        $this->readme = str_replace($search, $replace, $this->readme);
+    }
+
+    protected function appendToGitignore(string $toIgnore): void
+    {
+        app('files')->append(base_path('.gitignore'), "\n{$toIgnore}");
     }
 }

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -37,17 +37,36 @@ class StarterKitPostInstall
             $originalAppKey = env('APP_KEY');
 
             $env = app('files')->get(base_path('.env.example'));
-            $env = str_replace('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"", $env);
-            $env = str_replace('APP_URL=', "APP_URL=\"{$originalAppUrl}\"", $env);
-            $env = str_replace('APP_KEY=', "APP_KEY=\"{$originalAppKey}\"", $env);
+            $env = str_replace(
+                [
+                    'APP_NAME="Statamic Peak"',
+                    'APP_URL=',
+                    'APP_KEY=',
+                ],
+                [
+                    "APP_NAME=\"{$appName}\"",
+                    "APP_URL=\"{$originalAppUrl}\"",
+                    "APP_KEY=\"{$originalAppKey}\""
+                ],
+                $env
+            );
 
             if (!$debugBarEnabled) {
                 $env = str_replace('DEBUGBAR_ENABLED=true', 'DEBUGBAR_ENABLED=false', $env);
             }
 
             $readme = app('files')->get(base_path('README.md'));
-            $readme = str_replace('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"", $readme);
-            $readme = str_replace('APP_KEY=', "APP_KEY=\"{$originalAppKey}\"", $readme);
+            $readme = str_replace(
+                [
+                    'APP_NAME="Statamic Peak"',
+                    'APP_KEY='
+                ],
+                [
+                    "APP_NAME=\"{$appName}\"",
+                    "APP_KEY=\"{$originalAppKey}\""
+                ],
+                $readme
+            );
 
             if (
                 confirm(

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Prompt;
 use LaravelLang\Publisher\Facades\Helpers\Locales;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -16,9 +17,11 @@ class StarterKitPostInstall
 {
     protected string $env = '';
     protected string $readme = '';
+    protected bool $interactive = true;
 
-    public function handle(): void
+    public function handle($console): void
     {
+        $this->applyInteractivity($console);
         $this->overwriteEnvWithPresets();
         $this->initializeGitAndConfigureGitignore();
         $this->installNodeDependencies();
@@ -26,6 +29,17 @@ class StarterKitPostInstall
         $this->installTranslations();
         $this->starPeakRepo();
         $this->finish();
+    }
+
+    protected function applyInteractivity($console): void
+    {
+        $this->interactive = !$console->option('no-interaction');
+
+        /**
+         * Interactivity should be inherited but seems like there is a bug in Prompts where it stays
+         * without interaction when a command was run before with `--no-interaction` flag.
+         */
+        Prompt::interactive($this->interactive);
     }
 
     protected function overwriteEnvWithPresets(): void

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -1,16 +1,38 @@
 <?php
 
+use LaravelLang\Publisher\Facades\Helpers\Locales;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\warning;
+
 
 class StarterKitPostInstall
 {
-    public function handle($console)
+    public function handle(): void
     {
-        if ($console->confirm('Do you want overwrite your `.env` file with the Peak presets?', true)) {
-            $appName = $console->ask('What should be your app name?');
+        if (
+            confirm(
+                label: 'Do you want overwrite your `.env` file with the Peak presets?',
+                default: true,
+            )
+        ) {
+            $appName = text(
+                label: 'What should be your app name?',
+                placeholder: 'Statamic Peak',
+                default: 'Statamic Peak',
+            );
             $appName = preg_replace('/([\'|\"|#])/m', '', $appName);
-            $debugBarEnabled = $console->confirm('Do you want to use the debugbar?', false);
+
+            $debugBarEnabled = confirm(
+                label: 'Do you want to use the debugbar?',
+                default: false,
+            );
+
             $originalAppUrl = env('APP_URL');
             $originalAppKey = env('APP_KEY');
 
@@ -18,7 +40,8 @@ class StarterKitPostInstall
             $env = str_replace('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"", $env);
             $env = str_replace('APP_URL=', "APP_URL=\"{$originalAppUrl}\"", $env);
             $env = str_replace('APP_KEY=', "APP_KEY=\"{$originalAppKey}\"", $env);
-            if (! $debugBarEnabled) {
+
+            if (!$debugBarEnabled) {
                 $env = str_replace('DEBUGBAR_ENABLED=true', 'DEBUGBAR_ENABLED=false', $env);
             }
 
@@ -26,12 +49,22 @@ class StarterKitPostInstall
             $readme = str_replace('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"", $readme);
             $readme = str_replace('APP_KEY=', "APP_KEY=\"{$originalAppKey}\"", $readme);
 
-            if ($console->confirm('Do you want use Imagick as an image processor instead of GD?', true)) {
+            if (
+                confirm(
+                    label: 'Do you want use Imagick as an image processor instead of GD?',
+                    default: true,
+                )
+            ) {
                 $env = str_replace('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick', $env);
                 $readme = str_replace('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick', $readme);
             }
 
-            if ($console->confirm('Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?', false)) {
+            if (
+                confirm(
+                    label: 'Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?',
+                    default: false,
+                )
+            ) {
                 $env = str_replace('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true', $env);
                 $readme = str_replace('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true', $readme);
             }
@@ -40,100 +73,156 @@ class StarterKitPostInstall
             app('files')->put(base_path('README.md'), $readme);
         }
 
-        if ($console->confirm('Do you want to init a git repo and configure gitignore?', true)) {
+        if (
+            confirm(
+                label: 'Do you want to init a git repo and configure gitignore?',
+                default: true,
+            )
+        ) {
             $process = new Process(['git', 'init']);
             try {
                 $process->mustRun();
-                $console->info('Repo initialised.');
+                info('Repo initialised.');
             } catch (ProcessFailedException $exception) {
-                $console->info($exception->getMessage());
+                error($exception->getMessage());
             }
 
-            if ($console->confirm('Do you want to exclude the `public/build` folder from git?', true)) {
+            if (
+                confirm(
+                    label: 'Do you want to exclude the `public/build` folder from git?',
+                    default: true,
+                )
+            ) {
                 app('files')->append(base_path('.gitignore'), "\n/public/build/");
             }
 
-            if ($console->confirm('Do you want to exclude the `users` folder from git?', false)) {
+            if (
+                confirm(
+                    label: 'Do you want to exclude the `users` folder from git?',
+                    default: false,
+                )
+            ) {
                 app('files')->append(base_path('.gitignore'), "\n/users");
             }
 
-            if ($console->confirm('Do you want to exclude the `storage/form` folder from git?', false)) {
+            if (
+                confirm(
+                    label: 'Do you want to exclude the `storage/form` folder from git?',
+                    default: false,
+                )
+            ) {
                 app('files')->append(base_path('.gitignore'), "\n/storage/forms");
             }
         }
 
-        if ($console->confirm('Do you want to install npm dependencies?', true)) {
+        if (
+            confirm(
+                label: 'Do you want to install npm dependencies?',
+                default: true,
+            )
+        ) {
             $process = new Process(['npm', 'i']);
             try {
                 $process->mustRun();
-                $console->info('Dependencies installed.');
+                info('Dependencies installed.');
             } catch (ProcessFailedException $exception) {
-                $console->info($exception->getMessage());
+                error($exception->getMessage());
             }
         }
 
-        if ($console->confirm('Do you want to `npm i puppeteer` and `composer require spatie/browsershot` for generating social images?', true)) {
+        if (
+            confirm(
+                label: 'Do you want to `npm i puppeteer` and `composer require spatie/browsershot` for generating social images?',
+                default: true,
+            )
+        ) {
             $process = new Process(['npm', 'i', 'puppeteer']);
             try {
                 $process->mustRun();
-                $console->info('Puppeteer installed.');
+                info('Puppeteer installed.');
             } catch (ProcessFailedException $exception) {
-                $console->info($exception->getMessage());
+                error($exception->getMessage());
             }
 
             $process = new Process(['composer', 'require', 'spatie/browsershot']);
             try {
                 $process->mustRun();
-                $console->info('Browsershot installed.');
+                info('Browsershot installed.');
             } catch (ProcessFailedException $exception) {
-                $console->info($exception->getMessage());
+                error($exception->getMessage());
             }
         }
 
-        if ($console->confirm('Do you want to install missing Laravel translation files using the Laravel Lang package?', true)) {
+        if (
+            confirm(
+                label: 'Do you want to install missing Laravel translation files using the Laravel Lang package?',
+                default: true,
+            )
+        ) {
             $process = new Process(['composer', 'require', 'laravel-lang/common', '--dev']);
             try {
                 $process->mustRun();
-                $console->info('Laravel Lang installed.');
-            } catch (ProcessFailedException $exception) {
-                $console->info($exception->getMessage());
-            }
 
-            $console->info('Enter the handles of the languages you want to install. Press enter when you\'re done.');
-            do {
-                if ($handle = $console->ask('Handle of language (e.g. "nl")')) {
-                    $process = new Process(['php', 'artisan', 'lang:add', $handle]);
-                    try {
-                        $process->mustRun();
-                        $console->info("Language \"{$handle}\" installed.");
-                    } catch (ProcessFailedException $exception) {
-                        $console->info($exception->getMessage());
+                info('Laravel Lang installed.');
+
+                info('Enter the handles of the languages you want to install. Press enter when you\'re done.');
+
+                $installedLanguages = collect();
+
+                do {
+                    if (
+                        $handle = suggest(
+                            label: 'Handle of language',
+                            options: fn($value) => collect(Locales::available())
+                                ->filter(fn(string $language) => str_contains($language, $value) && !$installedLanguages->contains($language))
+                                ->values()
+                                ->toArray(),
+                            validate: fn(string $value) => match (true) {
+                                $value && !Locales::isAvailable($value) => 'Not supported by Laravel Lang.',
+                                $value && $installedLanguages->contains($value) => 'Already installed.',
+                                default => null,
+                            },
+                        )
+                    ) {
+                        $process = new Process(['php', 'artisan', 'lang:add', $handle]);
+                        try {
+                            $process->mustRun();
+                            $installedLanguages->push($handle);
+                            info("Language \"{$handle}\" installed.");
+                        } catch (ProcessFailedException $exception) {
+                            error($exception->getMessage());
+                        }
                     }
-                }
-            } while ($handle !== null);
+                } while ($handle);
+            } catch (ProcessFailedException $exception) {
+                error($exception->getMessage());
+            }
         }
 
-        if ($console->confirm('Would you like to star the Peak repo?', false)) {
-            if (PHP_OS_FAMILY == 'Darwin') {
+        if (
+            confirm(
+                label: 'Would you like to star the Peak repo?',
+                default: false,
+            )
+        ) {
+            if (PHP_OS_FAMILY === 'Darwin') {
                 exec('open https://github.com/studio1902/statamic-peak');
             }
-            if (PHP_OS_FAMILY == 'Windows') {
+
+            if (PHP_OS_FAMILY === 'Windows') {
                 exec('start https://github.com/studio1902/statamic-peak');
             }
-            if (PHP_OS_FAMILY == 'Linux') {
+
+            if (PHP_OS_FAMILY === 'Linux') {
                 exec('xdg-open https://github.com/studio1902/statamic-peak');
             }
 
-            $console->info('Thank you!');
+            info('Thank you!');
         }
 
-        $console->info('<info>[✓]</info> Peak is installed. Enjoy the view!');
-        $console->newline();
-        $console->warn('Run `php please peak:clear-site` to get rid of default content.');
-        $console->newline();
-        $console->warn('Run `php please peak:install-preset` to install premade sets onto your website.');
-        $console->newline();
-        $console->warn('Run `php please peak:install-block` to install premade blocks onto your page builder.');
-        $console->newline();
+        info('<info>[✓] Peak is installed. Enjoy the view!</info>');
+        warning('Run `php please peak:clear-site` to get rid of default content.');
+        warning('Run `php please peak:install-preset` to install premade sets onto your website.');
+        warning('Run `php please peak:install-block` to install premade blocks onto your page builder.');
     }
 }

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -13,232 +13,269 @@ use function Laravel\Prompts\warning;
 
 class StarterKitPostInstall
 {
+    protected string $env = '';
+    protected string $readme = '';
+
     public function handle(): void
     {
-        if (
-            confirm(
-                label: 'Do you want overwrite your `.env` file with the Peak presets?',
-                default: true,
-            )
-        ) {
-            $appName = text(
-                label: 'What should be your app name?',
-                placeholder: 'Statamic Peak',
-                default: 'Statamic Peak',
-            );
-            $appName = preg_replace('/([\'|\"|#])/m', '', $appName);
+        $this->overwriteEnvWithPresets();
+        $this->initializeGitAndConfigureGitignore();
+        $this->installNodeDependencies();
+        $this->installPuppeteerAndBrowsershot();
+        $this->installTranslations();
+        $this->starPeakRepo();
+        $this->finish();
+    }
 
-            $debugBarEnabled = confirm(
-                label: 'Do you want to use the debugbar?',
-                default: false,
-            );
-
-            $originalAppUrl = env('APP_URL');
-            $originalAppKey = env('APP_KEY');
-
-            $env = app('files')->get(base_path('.env.example'));
-            $env = str_replace(
-                [
-                    'APP_NAME="Statamic Peak"',
-                    'APP_URL=',
-                    'APP_KEY=',
-                ],
-                [
-                    "APP_NAME=\"{$appName}\"",
-                    "APP_URL=\"{$originalAppUrl}\"",
-                    "APP_KEY=\"{$originalAppKey}\""
-                ],
-                $env
-            );
-
-            if (!$debugBarEnabled) {
-                $env = str_replace('DEBUGBAR_ENABLED=true', 'DEBUGBAR_ENABLED=false', $env);
-            }
-
-            $readme = app('files')->get(base_path('README.md'));
-            $readme = str_replace(
-                [
-                    'APP_NAME="Statamic Peak"',
-                    'APP_KEY='
-                ],
-                [
-                    "APP_NAME=\"{$appName}\"",
-                    "APP_KEY=\"{$originalAppKey}\""
-                ],
-                $readme
-            );
-
-            if (
-                confirm(
-                    label: 'Do you want use Imagick as an image processor instead of GD?',
-                    default: true,
-                )
-            ) {
-                $env = str_replace('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick', $env);
-                $readme = str_replace('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick', $readme);
-            }
-
-            if (
-                confirm(
-                    label: 'Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?',
-                    default: false,
-                )
-            ) {
-                $env = str_replace('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true', $env);
-                $readme = str_replace('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true', $readme);
-            }
-
-            app('files')->put(base_path('.env'), $env);
-            app('files')->put(base_path('README.md'), $readme);
+    protected function overwriteEnvWithPresets(): void
+    {
+        if (!confirm(label: 'Do you want overwrite your `.env` file with the Peak presets?', default: true,)) {
+            return;
         }
 
-        if (
-            confirm(
-                label: 'Do you want to init a git repo and configure gitignore?',
-                default: true,
-            )
-        ) {
-            $process = new Process(['git', 'init']);
-            try {
-                $process->mustRun();
-                info('Repo initialised.');
-            } catch (ProcessFailedException $exception) {
-                error($exception->getMessage());
-            }
+        $this->loadPresetEnvAndReadme();
 
-            if (
-                confirm(
-                    label: 'Do you want to exclude the `public/build` folder from git?',
-                    default: true,
-                )
-            ) {
-                app('files')->append(base_path('.gitignore'), "\n/public/build/");
-            }
+        $this->setAppName();
+        $this->setAppUrl();
+        $this->setAppKey();
 
-            if (
-                confirm(
-                    label: 'Do you want to exclude the `users` folder from git?',
-                    default: false,
-                )
-            ) {
-                app('files')->append(base_path('.gitignore'), "\n/users");
-            }
+        $this->useDebugbar();
+        $this->useImagick();
+        $this->enableSaveCachedImages();
 
-            if (
-                confirm(
-                    label: 'Do you want to exclude the `storage/form` folder from git?',
-                    default: false,
-                )
-            ) {
-                app('files')->append(base_path('.gitignore'), "\n/storage/forms");
-            }
+        $this->writeEnvAndReadme();
+    }
+
+    protected function loadPresetEnvAndReadme(): void
+    {
+        $this->env = app('files')->get(base_path('.env.example'));
+        $this->readme = app('files')->get(base_path('README.md'));
+    }
+
+    protected function setAppName(): void
+    {
+        $appName = text(
+            label: 'What should be your app name?',
+            placeholder: 'Statamic Peak',
+            default: 'Statamic Peak',
+        );
+
+        $appName = preg_replace('/([\'|\"|#])/m', '', $appName);
+
+        $this->replaceInEnv('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"");
+        $this->replaceInReadme('APP_NAME="Statamic Peak"', "APP_NAME=\"{$appName}\"");
+    }
+
+    protected function replaceInEnv(string $search, string $replace): void
+    {
+        $this->env = str_replace($search, $replace, $this->env);
+    }
+
+    protected function replaceInReadme(string $search, string $replace): void
+    {
+        $this->readme = str_replace($search, $replace, $this->readme);
+    }
+
+    protected function setAppUrl(): void
+    {
+        $appUrl = env('APP_URL');
+
+        $this->replaceInEnv('APP_URL=', "APP_URL=\"{$appUrl}\"");
+    }
+
+    protected function setAppKey(): void
+    {
+        $appKey = env('APP_KEY');
+
+        $this->replaceInEnv('APP_KEY=', "APP_KEY=\"{$appKey}\"");
+        $this->replaceInReadme('APP_KEY=', "APP_KEY=\"{$appKey}\"");
+    }
+
+    protected function useDebugbar(): void
+    {
+        if (confirm(label: 'Do you want to use the debugbar?', default: false,)) {
+            return;
         }
 
-        if (
-            confirm(
-                label: 'Do you want to install npm dependencies?',
-                default: true,
-            )
-        ) {
-            $process = new Process(['npm', 'i']);
-            try {
-                $process->mustRun();
-                info('Dependencies installed.');
-            } catch (ProcessFailedException $exception) {
-                error($exception->getMessage());
-            }
+        $this->replaceInEnv('DEBUGBAR_ENABLED=true', 'DEBUGBAR_ENABLED=false');
+    }
+
+    protected function useImagick(): void
+    {
+        if (!confirm(label: 'Do you want use Imagick as an image processor instead of GD?', default: true,)) {
+            return;
         }
 
-        if (
-            confirm(
-                label: 'Do you want to `npm i puppeteer` and `composer require spatie/browsershot` for generating social images?',
-                default: true,
-            )
-        ) {
-            $process = new Process(['npm', 'i', 'puppeteer']);
-            try {
-                $process->mustRun();
-                info('Puppeteer installed.');
-            } catch (ProcessFailedException $exception) {
-                error($exception->getMessage());
-            }
+        $this->replaceInEnv('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick');
+        $this->replaceInReadme('#IMAGE_MANIPULATION_DRIVER=imagick', 'IMAGE_MANIPULATION_DRIVER=imagick');
+    }
 
-            $process = new Process(['composer', 'require', 'spatie/browsershot']);
-            try {
-                $process->mustRun();
-                info('Browsershot installed.');
-            } catch (ProcessFailedException $exception) {
-                error($exception->getMessage());
-            }
+    protected function enableSaveCachedImages(): void
+    {
+        if (!confirm(label: 'Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?', default: false,)) {
+            return;
         }
 
-        if (
-            confirm(
-                label: 'Do you want to install missing Laravel translation files using the Laravel Lang package?',
-                default: true,
-            )
-        ) {
-            $process = new Process(['composer', 'require', 'laravel-lang/common', '--dev']);
-            try {
-                $process->mustRun();
+        $this->replaceInEnv('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true');
+        $this->replaceInReadme('SAVE_CACHED_IMAGES=false', 'SAVE_CACHED_IMAGES=true');
+    }
 
-                info('Laravel Lang installed.');
+    protected function writeEnvAndReadme(): void
+    {
+        app('files')->put(base_path('.env'), $this->env);
+        app('files')->put(base_path('README.md'), $this->readme);
+    }
 
-                info('Enter the handles of the languages you want to install. Press enter when you\'re done.');
-
-                $installedLanguages = collect();
-
-                do {
-                    if (
-                        $handle = suggest(
-                            label: 'Handle of language',
-                            options: fn($value) => collect(Locales::available())
-                                ->filter(fn(string $language) => str_contains($language, $value) && !$installedLanguages->contains($language))
-                                ->values()
-                                ->toArray(),
-                            validate: fn(string $value) => match (true) {
-                                $value && !Locales::isAvailable($value) => 'Not supported by Laravel Lang.',
-                                $value && $installedLanguages->contains($value) => 'Already installed.',
-                                default => null,
-                            },
-                        )
-                    ) {
-                        $process = new Process(['php', 'artisan', 'lang:add', $handle]);
-                        try {
-                            $process->mustRun();
-                            $installedLanguages->push($handle);
-                            info("Language \"{$handle}\" installed.");
-                        } catch (ProcessFailedException $exception) {
-                            error($exception->getMessage());
-                        }
-                    }
-                } while ($handle);
-            } catch (ProcessFailedException $exception) {
-                error($exception->getMessage());
-            }
+    protected function initializeGitAndConfigureGitignore(): void
+    {
+        if (!confirm(label: 'Do you want to init a git repo and configure gitignore?', default: true,)) {
+            return;
         }
 
-        if (
-            confirm(
-                label: 'Would you like to star the Peak repo?',
-                default: false,
-            )
-        ) {
-            if (PHP_OS_FAMILY === 'Darwin') {
-                exec('open https://github.com/studio1902/statamic-peak');
-            }
+        $this->initializeGitRepo();
 
-            if (PHP_OS_FAMILY === 'Windows') {
-                exec('start https://github.com/studio1902/statamic-peak');
-            }
+        $this->excludeBuildFolderFromGit();
+        $this->excludeUsersFolderFromGit();
+        $this->excludeFormsFolderFromGit();
+    }
 
-            if (PHP_OS_FAMILY === 'Linux') {
-                exec('xdg-open https://github.com/studio1902/statamic-peak');
-            }
+    protected function initializeGitRepo(): void
+    {
+        $this->runCommand('git init', fn() => info('Repo initialised.'));
+    }
 
-            info('Thank you!');
+    protected function runCommand(string $command, callable $callback): void
+    {
+        $process = new Process(explode(' ', $command));
+        try {
+            $process->mustRun();
+            $callback();
+        } catch (ProcessFailedException $exception) {
+            error($exception->getMessage());
+        }
+    }
+
+    protected function excludeBuildFolderFromGit(): void
+    {
+        if (!confirm(label: 'Do you want to exclude the `public/build` folder from git?', default: true,)) {
+            return;
         }
 
+        $this->appendToGitignore('/public/build/');
+    }
+
+    protected function appendToGitignore(string $toIgnore): void
+    {
+        app('files')->append(base_path('.gitignore'), "\n{$toIgnore}");
+    }
+
+    protected function excludeUsersFolderFromGit(): void
+    {
+        if (!confirm(label: 'Do you want to exclude the `users` folder from git?', default: false,)) {
+            return;
+        }
+
+        $this->appendToGitignore('/users');
+    }
+
+    protected function excludeFormsFolderFromGit(): void
+    {
+        if (!confirm(label: 'Do you want to exclude the `storage/form` folder from git?', default: false,)) {
+            return;
+        }
+
+        $this->appendToGitignore('/storage/forms');
+    }
+
+    protected function installNodeDependencies(): void
+    {
+        if (!confirm(label: 'Do you want to install npm dependencies?', default: true,)) {
+            return;
+        }
+
+        $this->runCommand('npm i', fn() => info('Dependencies installed.'));
+    }
+
+    protected function installPuppeteerAndBrowsershot(): void
+    {
+        if (!confirm(label: 'Do you want to `npm i puppeteer` and `composer require spatie/browsershot` for generating social images?', default: true,)) {
+            return;
+        }
+
+        $this->installPuppeteer();
+        $this->installBrowsershot();
+    }
+
+    protected function installPuppeteer(): void
+    {
+        $this->runCommand('npm i puppeteer', fn() => info('Puppeteer installed.'));
+    }
+
+    protected function installBrowsershot(): void
+    {
+        $this->runCommand('composer require spatie/browsershot', fn() => info('Browsershot installed.'));
+    }
+
+    protected function installTranslations(): void
+    {
+        if (!confirm(label: 'Do you want to install missing Laravel translation files using the Laravel Lang package?', default: true,)) {
+            return;
+        }
+
+        $this->runCommand('composer require laravel-lang/common --dev', function () {
+            info('Laravel Lang installed.');
+
+            info('Enter the handles of the languages you want to install. Press enter when you\'re done.');
+
+            $installedLanguages = collect();
+            do {
+                if (
+                    $handle = suggest(
+                        label: 'Handle of language',
+                        options: fn($value) => collect(Locales::available())
+                            ->filter(fn(string $language) => str_contains($language, $value) && !$installedLanguages->contains($language))
+                            ->values()
+                            ->toArray(),
+                        validate: fn(string $value) => match (true) {
+                            $value && !Locales::isAvailable($value) => 'Not supported by Laravel Lang.',
+                            $value && $installedLanguages->contains($value) => 'Already installed.',
+                            default => null,
+                        },
+                    )
+                ) {
+                    $this->runCommand("php artisan lang:add {$handle}", function () use ($handle, $installedLanguages) {
+                        $installedLanguages->push($handle);
+                        info("Language \"{$handle}\" installed.");
+                    });
+                }
+            } while ($handle);
+        });
+    }
+
+    protected function starPeakRepo(): void
+    {
+        if (!confirm(label: 'Would you like to star the Peak repo?', default: false,)) {
+            return;
+        }
+
+        if (PHP_OS_FAMILY === 'Darwin') {
+            exec('open https://github.com/studio1902/statamic-peak');
+        }
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            exec('start https://github.com/studio1902/statamic-peak');
+        }
+
+        if (PHP_OS_FAMILY === 'Linux') {
+            exec('xdg-open https://github.com/studio1902/statamic-peak');
+        }
+
+        info('Thank you!');
+    }
+
+    protected function finish(): void
+    {
+        //TODO[mr]: check if <info> is needed for green (11.09.23 mr)
         info('<info>[✓] Peak is installed. Enjoy the view!</info>');
         warning('Run `php please peak:clear-site` to get rid of default content.');
         warning('Run `php please peak:install-preset` to install premade sets onto your website.');

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -44,7 +44,7 @@ class StarterKitPostInstall
 
     protected function overwriteEnvWithPresets(): void
     {
-        if (!confirm(label: 'Do you want overwrite your `.env` file with the Peak presets?', default: true,)) {
+        if (!confirm(label: 'Do you want overwrite your `.env` file with the Peak presets?', default: true)) {
             return;
         }
 
@@ -65,7 +65,7 @@ class StarterKitPostInstall
 
     protected function initializeGitAndConfigureGitignore(): void
     {
-        if (!confirm(label: 'Do you want to init a git repo and configure gitignore?', default: true,)) {
+        if (!confirm(label: 'Do you want to init a git repo and configure gitignore?', default: true)) {
             return;
         }
 
@@ -78,7 +78,7 @@ class StarterKitPostInstall
 
     protected function installNodeDependencies(): void
     {
-        if (!confirm(label: 'Do you want to install npm dependencies?', default: true,)) {
+        if (!confirm(label: 'Do you want to install npm dependencies?', default: true)) {
             return;
         }
 
@@ -91,7 +91,7 @@ class StarterKitPostInstall
 
     protected function installPuppeteerAndBrowsershot(): void
     {
-        if (!confirm(label: 'Do you want to `npm i puppeteer` and `composer require spatie/browsershot` for generating social images?', default: true,)) {
+        if (!confirm(label: 'Do you want to `npm i puppeteer` and `composer require spatie/browsershot` for generating social images?', default: true)) {
             return;
         }
 
@@ -101,7 +101,7 @@ class StarterKitPostInstall
 
     protected function installTranslations(): void
     {
-        if (!confirm(label: 'Do you want to install missing Laravel translation files using the Laravel Lang package?', default: true,)) {
+        if (!confirm(label: 'Do you want to install missing Laravel translation files using the Laravel Lang package?', default: true)) {
             return;
         }
 
@@ -114,7 +114,7 @@ class StarterKitPostInstall
 
     protected function starPeakRepo(): void
     {
-        if (!confirm(label: 'Would you like to star the Peak repo?', default: false,)) {
+        if (!confirm(label: 'Would you like to star the Peak repo?', default: false)) {
             return;
         }
 
@@ -179,7 +179,7 @@ class StarterKitPostInstall
 
     protected function useDebugbar(): void
     {
-        if (confirm(label: 'Do you want to use the debugbar?', default: false,)) {
+        if (confirm(label: 'Do you want to use the debugbar?', default: false)) {
             return;
         }
 
@@ -188,7 +188,7 @@ class StarterKitPostInstall
 
     protected function useImagick(): void
     {
-        if (!confirm(label: 'Do you want use Imagick as an image processor instead of GD?', default: true,)) {
+        if (!confirm(label: 'Do you want use Imagick as an image processor instead of GD?', default: true)) {
             return;
         }
 
@@ -198,7 +198,7 @@ class StarterKitPostInstall
 
     protected function enableSaveCachedImages(): void
     {
-        if (!confirm(label: 'Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?', default: false,)) {
+        if (!confirm(label: 'Do you want to enable `SAVE_CACHED_IMAGES` (slower initial page load)?', default: false)) {
             return;
         }
 
@@ -223,7 +223,7 @@ class StarterKitPostInstall
 
     protected function excludeBuildFolderFromGit(): void
     {
-        if (!confirm(label: 'Do you want to exclude the `public/build` folder from git?', default: true,)) {
+        if (!confirm(label: 'Do you want to exclude the `public/build` folder from git?', default: true)) {
             return;
         }
 
@@ -232,7 +232,7 @@ class StarterKitPostInstall
 
     protected function excludeUsersFolderFromGit(): void
     {
-        if (!confirm(label: 'Do you want to exclude the `users` folder from git?', default: false,)) {
+        if (!confirm(label: 'Do you want to exclude the `users` folder from git?', default: false)) {
             return;
         }
 
@@ -241,7 +241,7 @@ class StarterKitPostInstall
 
     protected function excludeFormsFolderFromGit(): void
     {
-        if (!confirm(label: 'Do you want to exclude the `storage/form` folder from git?', default: false,)) {
+        if (!confirm(label: 'Do you want to exclude the `storage/form` folder from git?', default: false)) {
             return;
         }
 

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -101,7 +101,7 @@ class StarterKitPostInstall
 
     protected function installTranslations(): void
     {
-        if (!confirm(label: 'Do you want to install missing Laravel translation files using the Laravel Lang package?', default: true)) {
+        if (!confirm(label: 'Do you want to install missing Laravel translation files using the Laravel Lang package?', default: $this->interactive)) {
             return;
         }
 
@@ -149,11 +149,11 @@ class StarterKitPostInstall
 
     protected function setAppName(): void
     {
-        //TODO[mr]: remove default and require (13.09.23 mr)
         $appName = text(
             label: 'What should be your app name?',
             placeholder: 'Statamic Peak',
-            default: 'Statamic Peak'
+            default: $this->interactive ? '' : 'Statamic Peak',
+            required: true,
         );
 
         $appName = preg_replace('/([\'|\"|#])/m', '', $appName);

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -1,7 +1,8 @@
 <?php
 
+use Illuminate\Support\Collection;
 use Laravel\Prompts\Prompt;
-use LaravelLang\Publisher\Facades\Helpers\Locales;
+use LaravelLang\Locales\Facades\Locales;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use function Laravel\Prompts\confirm;
@@ -106,6 +107,7 @@ class StarterKitPostInstall
         }
 
         if (!$this->installLaravelLang()) {
+            error('Could not install Laravel Lang.');
             return;
         }
 
@@ -284,7 +286,7 @@ class StarterKitPostInstall
 
     protected function installLaravelLang(): bool
     {
-        return $this->run(
+         return $this->run(
             command: 'composer require laravel-lang/common --dev',
             successMessage: 'Laravel Lang installed.',
             processingMessage: 'Installing Laravel Lang...',
@@ -319,11 +321,11 @@ class StarterKitPostInstall
         app('files')->append(base_path('.gitignore'), "\n{$toIgnore}");
     }
 
-    protected function selectLanguageToInstall(\Illuminate\Support\Collection $installedLanguages): string
+    protected function selectLanguageToInstall(Collection $installedLanguages): string
     {
         return suggest(
             label: 'Handle of language',
-            options: fn($value) => collect(Locales::available())
+            options: fn($value) => collect(Locales::raw()->available())
                 ->filter(fn(string $language) => str_contains($language, $value) && !$installedLanguages->contains($language))
                 ->values()
                 ->toArray(),

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -133,10 +133,11 @@ class StarterKitPostInstall
 
     protected function setAppName(): void
     {
+        //TODO[mr]: remove default and require (13.09.23 mr)
         $appName = text(
             label: 'What should be your app name?',
             placeholder: 'Statamic Peak',
-            required: true,
+            default: 'Statamic Peak'
         );
 
         $appName = preg_replace('/([\'|\"|#])/m', '', $appName);

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -52,3 +52,4 @@ dependencies:
   studio1902/statamic-peak-commands: ^2.0
   studio1902/statamic-peak-seo: ^6.0
   studio1902/statamic-peak-tools: ^3.0
+  laravel/prompts: ^0.1

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -52,4 +52,4 @@ dependencies:
   studio1902/statamic-peak-commands: ^2.0
   studio1902/statamic-peak-seo: ^6.0
   studio1902/statamic-peak-tools: ^3.0
-  laravel/prompts: ^0.1
+  laravel/framework: ^10.0


### PR DESCRIPTION
Changes proposed in this pull request:
Use Laravel Prompts for PostInstall Script

**Issues**
- [x] `LaravelLang` is not available after installation when using CLI. **Used current implementation for now.**
- [x] There is no interaction (Prompts use the default values) when installing via cli tool (`statamic new project studio1902/statamic-peak`) (https://github.com/statamic/cli/issues/62). **For now, we reapply the interaction state based on the passed options. But seems a bug in Prompts.**