### PR TITLE
DRY: refactor form fields

### DIFF
--- a/resources/views/vendor/statamic/forms/fields/date.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/date.antlers.html
@@ -1,0 +1,1 @@
+{{ partial:vendor/statamic/forms/fields/default input_type="date" }}

--- a/resources/views/vendor/statamic/forms/fields/integer.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/integer.antlers.html
@@ -1,17 +1,1 @@
-<!-- /vendor/statamic/forms/fields/integer.antlers.html -->
-<input
-    x-model="form.{{ handle }}"
-    @change="form.validate('{{ handle }}')"
-    :aria-invalid="form.invalid('{{ handle }}')"
-    :class="{ 'border-red-600 focus-visible:border-red-600': form.invalid('{{ handle }}') }"
-    class="w-full rounded border-neutral focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary motion-safe:transition caret-primary"
-    id="{{ handle }}"
-    name="{{ handle }}"
-    type="number"
-    {{ placeholder ?= 'placeholder="{placeholder}"' }}
-    {{ instructions_position == 'below' ?= 'aria-describedBy="{handle}-instructions"' }}
-    {{ character_limit ?= 'maxlength="{character_limit}"' }}
-    {{ old ?= 'value="{old}"' }}
-    {{ js_attributes }}
-/>
-<!-- End: /vendor/statamic/forms/fields/integer.antlers.html -->
+{{ partial:vendor/statamic/forms/fields/default input_type="number" }}

--- a/resources/views/vendor/statamic/forms/fields/text.antlers.html
+++ b/resources/views/vendor/statamic/forms/fields/text.antlers.html
@@ -1,18 +1,1 @@
-<!-- /vendor/statamic/forms/fields/text.antlers.html -->
-<input
-    x-model="form.{{ handle }}"
-    @change="form.validate('{{ handle }}')"
-    :aria-invalid="form.invalid('{{ handle }}')"
-    :class="{ 'border-red-600 focus-visible:border-red-600': form.invalid('{{ handle }}') }"
-    class="w-full rounded border-neutral focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary motion-safe:transition caret-primary"
-    id="{{ handle }}"
-    name="{{ handle }}"
-    type="{{ input_type ?? 'text' }}"
-    {{ placeholder ?= 'placeholder="{placeholder}"' }}
-    {{ instructions_position == 'below' ?= 'aria-describedBy="{handle}-instructions"' }}
-    {{ character_limit ?= 'maxlength="{character_limit}"' }}
-    {{ old ?= 'value="{old}"' }}
-    {{ js_attributes }}
-/>
-{{ test }}
-<!-- End: /vendor/statamic/forms/fields/text.antlers.html -->
+{{ partial:vendor/statamic/forms/fields/default }}


### PR DESCRIPTION
Changes proposed in this pull request:
-
This PR cleans up the form fields and includes the ``default`` passing the ``input_type`` into it.

@robdekort I guess the ``{{ test }} `` inside the text partial (last line) was not intentional and was removed.