### PR TITLE
Button tags should not use default link behaviour

### DIFF
--- a/resources/views/snippets/_button_attributes.antlers.html
+++ b/resources/views/snippets/_button_attributes.antlers.html
@@ -10,7 +10,7 @@
     (link_type == 'tel') => 'href="tel:{{ tel }}"',
     (link_type == 'sms') => 'href="sms:{{ sms }}"',
     (link_type == 'asset') => 'href="{{ asset }}" download',
-    () => 'href="{{ url }}"'
+    (as !== 'button') => 'href="{{ url }}"'
 )}}
 {{ target_blank ?= 'rel="noopener" target="_blank"' }}
 {{ attr_title ?= 'title="{{ attr_title }}"' }}


### PR DESCRIPTION
Fixes issue where `{{ partial:components/button as="button"  label="My button" }}` would inherit the default `href` attribute.

Changes proposed in this pull request:
- Add condition to avoid default 'href' attribute for button tags.
