### PR TITLE
Form improvements

### DIFF
--- a/resources/views/email/form_owner.antlers.html
+++ b/resources/views/email/form_owner.antlers.html
@@ -48,11 +48,11 @@
                                                             <td style='vertical-align:top; font-family:"Source Code Pro", monospace; padding:11px' valign="top">
                                                                 <table cellpadding="0" cellspacing="0" border="0" style="width:100%" width="100%">
                                                                     {{ fields }}
-                                                                        {{ if value && handle !== 'consent' }}
+                                                                        {{ if value && {config['visibility']} !== 'hidden' }}
                                                                             <tr>
                                                                                 <td style='vertical-align:top; font-family:"Source Code Pro", monospace; padding:11px; border-bottom:#e3e3da 1px solid; font-size:14px' valign="top">
                                                                                     <strong>{{ trans :key="display" :locale="site:locale" }}:</strong><br>
-                                                                                    <pre style="white-space:pre-line; font-family:inherit; margin:0">{{ if (value | is_array) }}<ul>{{ value }}<li>{{ value }}</li>{{ /value }}</ul>{{ else }}{{ value }}{{ /if }}</pre>
+                                                                                    <pre style="font-family:inherit; margin:0">{{ if (value | is_array) }}<ul>{{ value }}<li>{{ value:label ?? value }}</li>{{ /value }}</ul>{{ else }}{{ value:label ?? value }}{{ /if }}</pre>
                                                                                 </td>
                                                                             </tr>
                                                                         {{ /if }}

--- a/resources/views/email/form_owner_text.antlers.html
+++ b/resources/views/email/form_owner_text.antlers.html
@@ -7,14 +7,14 @@
 
 -
 {{ fields }}
-{{ if handle !== 'consent' }}
+{{ if {config['visibility']} !== 'hidden' }}
 {{ trans :key="display" :locale="locale" }}:
 {{ if (value | is_array) }}
 {{ value }}
-{{ value }}
+{{ value:label ?? value }}
 {{ /value }}
 {{ else }}
-{{ value }}
+{{ value:label ?? value }}
 {{ /if }}
 {{ /if }}
 {{ /fields }}

--- a/resources/views/email/form_sender.antlers.html
+++ b/resources/views/email/form_sender.antlers.html
@@ -60,11 +60,11 @@
                                                             <td style='vertical-align:top; font-family:"Source Code Pro", monospace; padding:11px' valign="top">
                                                                 <table cellpadding="0" cellspacing="0" border="0" style="width:100%" width="100%">
                                                                     {{ fields }}
-                                                                        {{ if value && handle !== 'consent' }}
+                                                                        {{ if value && {config['visibility']} !== 'hidden' }}
                                                                             <tr>
                                                                                 <td style='vertical-align:top; font-family:"Source Code Pro", monospace; padding:11px; border-bottom:#e3e3da 1px solid; font-size:14px' valign="top">
                                                                                     <strong>{{ trans :key="display" :locale="site:locale" }}:</strong><br>
-                                                                                    <pre style="white-space:pre-line; font-family:inherit; margin:0">{{ if (value | is_array) }}<ul>{{ value }}<li>{{ value }}</li>{{ /value }}</ul>{{ else }}{{ value }}{{ /if }}</pre>
+                                                                                    <pre style="font-family:inherit; margin:0">{{ if (value | is_array) }}<ul>{{ value }}<li>{{ value:label ?? value }}</li>{{ /value }}</ul>{{ else }}{{ value:label ?? value }}{{ /if }}</pre>
                                                                                 </td>
                                                                             </tr>
                                                                         {{ /if }}

--- a/resources/views/email/form_sender_text.antlers.html
+++ b/resources/views/email/form_sender_text.antlers.html
@@ -12,14 +12,14 @@
 
 -
 {{ fields }}
-{{ if handle !== 'consent' }}
+{{ if {config['visibility']} !== 'hidden' }}
 {{ trans :key="display" :locale="locale" }}:
 {{ if (value | is_array) }}
 {{ value }}
-{{ value }}
+{{ value:label ?? value }}
 {{ /value }}
 {{ else }}
-{{ value }}
+{{ value:label ?? value }}
 {{ /if }}
 {{ /if }}
 {{ /fields }}


### PR DESCRIPTION
This PR introduces the changes discussed in #369. 

Fixes #369 studio1902/statamic-peak-docs#16 .

Changes proposed in this pull request:
- Removed ``white-space: pre-line`` from HTML email templates
- Showing the label of a field if set
- Fields can now be hidden from the email templates by setting the ``visibility`` to ``hidden``
