### PR TITLE
Trim a trailing space from long form content pull quote

### DIFF
--- a/content/collections/pages/long-form-content.md
+++ b/content/collections/pages/long-form-content.md
@@ -48,7 +48,7 @@ page_builder:
           values:
             type: pull_quote
             size: lg
-            quote: 'Maecenas imperdiet mauris non posuere dignissim. Duis tempus molestie efficitur. '
+            quote: 'Maecenas imperdiet mauris non posuere dignissim. Duis tempus molestie efficitur.'
             author: 'Studio 1902'
       -
         type: paragraph


### PR DESCRIPTION
Trim a trailing space from the long-form content pull quote, which affects the close quote alignment.
I'm pretty sure this was a typo, but it fixes a rogue space.
