### PR TITLE
Fix grammar on caption

### DIFF
--- a/content/collections/pages/long-form-content.md
+++ b/content/collections/pages/long-form-content.md
@@ -108,7 +108,7 @@ page_builder:
           values:
             type: image
             size: xl
-            caption: 'Get on top of the Peak.'
+            caption: 'Get to the top of the Peak.'
             image: a-peak.jpg
       -
         type: paragraph


### PR DESCRIPTION
Tiny English fix, you get _to_ the top of a peak rather than on top of it.