### PR TITLE
Switch from === 'above' to != 'below' for instructions_position

### DIFF
--- a/resources/views/page_builder/_form.antlers.html
+++ b/resources/views/page_builder/_form.antlers.html
@@ -72,7 +72,7 @@
                                                     <sup class="text-red-700">*</sup>
                                                 {{ /if }}
 
-                                                {{ if field:instructions && instructions_position === 'above' }}
+                                                {{ if field:instructions && instructions_position != 'below' }}
                                                     {{ partial:typography/p class="mt-1 font-normal text-sm" content="{ trans :key="field:instructions" }" }}
                                                 {{ /if }}
                                             </label>


### PR DESCRIPTION
If I set instructions position to "above" for any form field, the instructions don't show.

The reason for this is that instead of `instructions_position` having the value `above`, the property simply doesn't exist. It seems to be included only when `instructions_position` is the non-default `below`. (Even though in Statamic 5, the default values should always be passed to the front end, it clearly doesn't for me in this case.)

Checking for `!= 'below'` seems a bit more robust/tolerant. (Let's just hope there won't be any `left` or `right`values in the future …!)