### PR TITLE
Updating Ploi's deploy script 

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -136,7 +136,7 @@ fi
 
 cd {SITE_DIRECTORY}
 git pull origin {BRANCH}
-composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
+{SITE_COMPOSER} install --no-interaction --prefer-dist --optimize-autoloader --no-dev
 
 npm ci
 npm run build


### PR DESCRIPTION
The example deploy script uses `composer` instead of `{SITE_COMPOSER}`. The latter uses the correct PHP version configured for the current website, instead of the global default.
