### PR TITLE
Better overflow handling for _button.antlers.html

### DIFF
--- a/export/resources/views/components/_button.antlers.html
+++ b/export/resources/views/components/_button.antlers.html
@@ -15,7 +15,7 @@
             inline-flex items-baseline gap-0.5 font-bold motion-safe:transition
             {{ switch(
                 (button_type === 'inline') => 'underline decoration-2 motion-safe:transition',
-                (button_type === 'button') => 'max-w-full py-3 px-4 rounded-sm leading-none no-underline select-none whitespace-nowrap',
+                (button_type === 'button') => 'max-w-full py-3 px-4 rounded-sm leading-none no-underline select-none',
             )}}
             {{ switch(
                 (button_type === 'inline' && !inverted) => 'text-neutral decoration-primary focus:outline-primary',
@@ -30,7 +30,7 @@
         {{ slot:attributes }}
         {{ !faux ?= { partial:statamic-peak-tools::snippets/button_attributes } }}
     >
-        <span class="text-ellipsis overflow-x-clip">
+        <span class="min-w-fit">
             {{ link_type == 'email' ? { label | obfuscate_email } : label }}
         </span>
 


### PR DESCRIPTION
Changes proposed in this pull request:

Based on the tip by Kevin Powell, buttons should be allowed to wrap in extreme situations using `min-width: fit-content;` instead of prevent wrapping which can cause overflows on smaller screens.

[Video Reference](https://www.youtube.com/watch?v=lUU2OAAg4Uw&t=825s)