### PR TITLE
Improve Forge deploy script to prevent errors on deployment

### DIFF
--- a/export/README.example.md
+++ b/export/README.example.md
@@ -172,8 +172,10 @@ $FORGE_COMPOSER install --no-interaction --prefer-dist --optimize-autoloader --n
 npm ci
 npm run build
 
+# Prevents multiple deployments from restarting PHP-FPM simultaneously
+touch /tmp/fpmlock 2>/dev/null || true
 ( flock -w 10 9 || exit 1
-    echo 'Restarting FPM...'; sudo -S service $FORGE_PHP_FPM reload ) 9>/tmp/fpmlock
+    echo 'Restarting FPM...'; sudo -S service $FORGE_PHP_FPM reload ) 9</tmp/fpmlock
 
 $FORGE_PHP artisan cache:clear
 $FORGE_PHP artisan config:cache


### PR DESCRIPTION
Recently, all our deployments on two forge-managed servers started to fail, all with the same error:
Prevent `/tmp/fpmlock: Permission denied` 

Changes proposed in this pull request:
- `touch /tmp/fpmlock 2>/dev/null || true`  → create lockfile if not already present
-  `9</tmp/fpmlock`  →  open for reading (opposed to `9>` for writing) 

This is also in accordance with the official Forge cookbook:
https://forge.laravel.com/docs/servers/cookbook#restarting-php-fpm