### PR TITLE
Fix missing ui-accent-bg

### DIFF
--- a/export/resources/preferences.yaml
+++ b/export/resources/preferences.yaml
@@ -30,6 +30,7 @@ theme:
     switch-bg: 'oklch(0.627 0.194 149.214)'
     content-bg: 'oklch(0.984 0.003 247.858)'
     progress-bar: 'oklch(93.86% 0.2018 122.24)'
+    ui-accent-bg: 'oklch(0.546 0.245 262.881)'
     dark-gray-50: 'oklch(0.985 0 0)'
     dark-gray-100: 'oklch(0.967 0.001 286.375)'
     dark-gray-150: 'oklch(0.956 0.0022 286.32)'


### PR DESCRIPTION
Before:
<img width="208" height="54" alt="image" src="https://github.com/user-attachments/assets/011a9bbd-91a3-47f4-8c3f-2dceac8d59de" />

After: 
<img width="191" height="46" alt="image" src="https://github.com/user-attachments/assets/1a8a94d9-2b50-4f15-9e9c-4167fddd6076" />
